### PR TITLE
Add supports to Insert Into

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -17,6 +17,8 @@
 
 package com.hortonworks.spark.atlas.sql
 
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
+
 import scala.util.Try
 
 import org.apache.atlas.model.instance.AtlasEntity
@@ -24,8 +26,8 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.{FileRelation, FileSourceScanExec}
-import org.apache.spark.sql.execution.command.{CreateDataSourceTableAsSelectCommand, LoadDataCommand}
-import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.command.{CreateViewCommand, CreateDataSourceTableAsSelectCommand, LoadDataCommand}
+import org.apache.spark.sql.execution.datasources.{InsertIntoHadoopFsRelationCommand, LogicalRelation}
 import org.apache.spark.sql.hive.execution._
 
 import com.hortonworks.spark.atlas.AtlasClientConf
@@ -37,61 +39,52 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
 
   object InsertIntoHiveTableHarvester extends Harvester[InsertIntoHiveTable] {
     override def harvest(node: InsertIntoHiveTable, qd: QueryDetail): Seq[AtlasEntity] = {
-      val child = node.query.asInstanceOf[Project].child
-      child match {
-        // case 3. INSERT INTO VALUES
-        case _: LocalRelation =>
-          Seq.empty
-
-        // case 4. INSERT INTO SELECT
-        case s: SubqueryAlias =>
-          // Prepare input entities
-          val fromTableIdentifier: Option[TableIdentifier] = s.child match {
-            case r: View => Some(r.desc.identifier)
-            case r: HiveTableRelation => Some(r.tableMeta.identifier)
-            case _ => None
-          }
-          require(fromTableIdentifier.isDefined, s"Fail to get input table from node $node")
-          val inputEntities = prepareEntities(fromTableIdentifier.get)
-
-          // Prepare output entities
-          val outTableIdentifier = node.table.identifier
-          val outputEntities = prepareEntities(outTableIdentifier)
-
-          // Create process entity
-          val inputTableEntity = List(inputEntities.head)
-          val outputTableEntity = List(outputEntities.head)
-          val pEntity = processToEntity(
-            qd.qe, qd.executionId, qd.executionTime, inputTableEntity, outputTableEntity)
-
-          Seq(pEntity) ++ inputEntities ++ outputEntities
-
-        // case 8. Multiple fromTables
-        case c: Filter =>
-          // Prepare input entities
-          val lChild = c.child.asInstanceOf[Join].left.asInstanceOf[SubqueryAlias]
-            .child.asInstanceOf[HiveTableRelation].tableMeta.identifier
-          val lInputs = prepareEntities(lChild)
-          val rChild = c.child.asInstanceOf[Join].right.asInstanceOf[SubqueryAlias]
-            .child.asInstanceOf[HiveTableRelation].tableMeta.identifier
-          val rInputs = prepareEntities(rChild)
-          val inputsEntities = lInputs ++ rInputs
-
-          // Prepare output entities
-          val outTableIdentifier = node.table.identifier
-          val outputsEntities = prepareEntities(outTableIdentifier)
-
-          // Create process entity
-          val inputTableEntities = List(lInputs.head, rInputs.head)
-          val outputTableEntities = List(outputsEntities.head)
-          val pEntity = processToEntity(
-            qd.qe, qd.executionId, qd.executionTime, inputTableEntities, outputTableEntities)
-
-          Seq(pEntity) ++ inputsEntities ++ outputsEntities
-
-        case _ =>
+      // source tables entities
+      val tChildren = node.query.collectLeaves()
+      val inputsEntities = tChildren.map {
+        case r: HiveTableRelation => tableToEntities(r.tableMeta)
+        case v: View => tableToEntities(v.desc)
+        case e =>
+          logWarn(s"Missing unknown leaf node: $e")
           Seq.empty
       }
+
+      // new table entity
+      val outputEntities = tableToEntities(node.table)
+
+      // create process entity
+      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
+      val outputTableEntities = List(outputEntities.head)
+      val pEntity = processToEntity(
+        qd.qe, qd.executionId, qd.executionTime, inputTablesEntities, outputTableEntities)
+      Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
+    }
+  }
+
+  object InsertIntoHadoopFsRelationHarvester extends Harvester[InsertIntoHadoopFsRelationCommand] {
+    override def harvest(node: InsertIntoHadoopFsRelationCommand, qd: QueryDetail): Seq[AtlasEntity] = {
+      // source tables entities
+      val tChildren = node.query.collectLeaves()
+      val inputsEntities = tChildren.map {
+        case r: HiveTableRelation => tableToEntities(r.tableMeta)
+        case v: View => tableToEntities(v.desc)
+        case l: LogicalRelation if l.relation.isInstanceOf[FileRelation] =>
+          l.catalogTable.map(tableToEntities(_)).getOrElse(
+            l.relation.asInstanceOf[FileRelation].inputFiles.map(external.pathToEntity).toSeq)
+        case e =>
+          logWarn(s"Missing unknown leaf node: $e")
+          Seq.empty
+      }
+
+      // new table entity
+      val outputEntities = tableToEntities(node.catalogTable.get)
+
+      // create process entity
+      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
+      val outputTableEntities = List(outputEntities.head)
+      val pEntity = processToEntity(
+        qd.qe, qd.executionId, qd.executionTime, inputTablesEntities, outputTableEntities)
+      Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
     }
   }
 
@@ -194,6 +187,28 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       Seq(pEntity, destEntity) ++ inputsEntities.flatten
     }
   }
+
+  object CreateViewHarvester extends Harvester[CreateViewCommand] {
+    override def harvest(node: CreateViewCommand, qd: QueryDetail): Seq[AtlasEntity] = {
+      // from table entities
+      val child = node.child.asInstanceOf[Project].child
+      val fromTableIdentifier = child.asInstanceOf[UnresolvedRelation].tableIdentifier
+      val inputEntities = prepareEntities(fromTableIdentifier)
+
+      // new view entities
+      val viewIdentifier = node.name
+      val outputEntities = prepareEntities(viewIdentifier)
+
+      // create process entity
+      val inputTableEntity = List(inputEntities.head)
+      val outputTableEntity = List(outputEntities.head)
+      val pEntity = processToEntity(
+        qd.qe, qd.executionId, qd.executionTime, inputTableEntity, outputTableEntity)
+
+      Seq(pEntity) ++ inputEntities ++ outputEntities
+    }
+  }
+
 
   private def prepareEntities(tableIdentifier: TableIdentifier): Seq[AtlasEntity] = {
     val tableName = tableIdentifier.table

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateViewHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateViewHarvesterSuite.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql
+
+import java.io.File
+import java.util
+
+import scala.collection.JavaConverters._
+import scala.util.Random
+
+import org.apache.atlas.AtlasClient
+import org.apache.atlas.model.instance.AtlasEntity
+import org.apache.commons.io.FileUtils
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.command.{ExecutedCommandExec, CreateViewCommand}
+import org.scalatest.{BeforeAndAfterAll, Matchers, FunSuite}
+
+import com.hortonworks.spark.atlas.types.external
+
+class CreateViewHarvesterSuite extends FunSuite with Matchers with BeforeAndAfterAll {
+  private var sparkSession: SparkSession = _
+  private val sourceTblName = "source_" + Random.nextInt(100000)
+  private val destinationViewName = "destination_" + Random.nextInt(100000)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    sparkSession = SparkSession.builder()
+      .master("local")
+      .config("spark.sql.catalogImplementation", "hive")
+      .getOrCreate()
+
+    sparkSession.sql(s"CREATE TABLE $sourceTblName (name string)")
+    sparkSession.sql(s"INSERT INTO TABLE $sourceTblName VALUES ('lucy'), ('tom')")
+  }
+
+  override def afterAll(): Unit = {
+    sparkSession.stop()
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
+    sparkSession = null
+
+    FileUtils.deleteDirectory(new File("metastore_db"))
+    FileUtils.deleteDirectory(new File("spark-warehouse"))
+
+    super.afterAll()
+  }
+
+  test("CREATE VIEW FROM TABLE") {
+    val qe = sparkSession.sql(s"CREATE VIEW $destinationViewName " +
+      s"AS SELECT * FROM $sourceTblName").queryExecution
+    val qd = QueryDetail(qe, 0L, 0L)
+
+    assert(qe.sparkPlan.isInstanceOf[ExecutedCommandExec])
+    val node = qe.sparkPlan.asInstanceOf[ExecutedCommandExec]
+    assert(node.cmd.isInstanceOf[CreateViewCommand])
+    val cmd = node.cmd.asInstanceOf[CreateViewCommand]
+
+    val entities = CommandsHarvester.CreateViewHarvester.harvest(cmd, qd)
+    val pEntity = entities.head
+
+    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
+    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
+    inputs.size() should be (1)
+
+    val inputTbl = inputs.asScala.head
+    inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+    inputTbl.getAttribute("name") should be (sourceTblName)
+    inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should be (
+      s"default.$sourceTblName@primary")
+
+    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
+    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
+    outputs.size() should be (1)
+    val outputView = outputs.asScala.head
+    outputView.getAttribute("name") should be (destinationViewName)
+    outputView.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
+      s"default.$destinationViewName")
+  }
+}

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
@@ -18,22 +18,21 @@
 package com.hortonworks.spark.atlas.sql
 
 import java.io.File
-
-import org.apache.commons.io.FileUtils
-import org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand
+import java.util
 
 import scala.collection.JavaConverters._
 import scala.util.Random
 
-import java.util
-
-import com.hortonworks.spark.atlas.types.{internal, external}
 import org.apache.atlas.AtlasClient
 import org.apache.atlas.model.instance.AtlasEntity
-import org.apache.spark.sql.SparkSession
+import org.apache.commons.io.FileUtils
+import org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
 import org.apache.spark.sql.hive.execution.InsertIntoHiveTable
+import org.apache.spark.sql.SparkSession
 import org.scalatest.{BeforeAndAfterAll, Matchers, FunSuite}
+
+import com.hortonworks.spark.atlas.types.external
 
 class InsertIntoHarvesterSuite extends FunSuite with Matchers with BeforeAndAfterAll {
 

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql
+
+import java.io.File
+
+import org.apache.commons.io.FileUtils
+import org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand
+
+import scala.collection.JavaConverters._
+import scala.util.Random
+
+import java.util
+
+import com.hortonworks.spark.atlas.types.{internal, external}
+import org.apache.atlas.AtlasClient
+import org.apache.atlas.model.instance.AtlasEntity
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.command.DataWritingCommandExec
+import org.apache.spark.sql.hive.execution.InsertIntoHiveTable
+import org.scalatest.{BeforeAndAfterAll, Matchers, FunSuite}
+
+class InsertIntoHarvesterSuite extends FunSuite with Matchers with BeforeAndAfterAll {
+
+  private var sparkSession: SparkSession = _
+  private val sourceHiveTblName = "source_" + Random.nextInt(100000)
+  private val sourceSparkTblName = "source_" + Random.nextInt(100000)
+  private val destinationHiveTblName = "destination_" + Random.nextInt(100000)
+  private val destinationSparkTblName = "destination_" + Random.nextInt(100000)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    sparkSession = SparkSession.builder()
+      .master("local")
+      .config("spark.sql.catalogImplementation", "hive")
+      .getOrCreate()
+
+    sparkSession.sql(s"CREATE TABLE $sourceHiveTblName (name string)")
+    sparkSession.sql(s"INSERT INTO TABLE $sourceHiveTblName VALUES ('a'), ('b'), ('c')")
+
+    sparkSession.sql(s"CREATE TABLE $sourceSparkTblName (name string) USING PARQUET")
+    sparkSession.sql(s"INSERT INTO TABLE $sourceSparkTblName VALUES ('d'), ('e'), ('f')")
+
+    sparkSession.sql(s"CREATE TABLE $destinationHiveTblName (name string)")
+    sparkSession.sql(s"CREATE TABLE $destinationSparkTblName (name string) USING PARQUET")
+  }
+
+  override def afterAll(): Unit = {
+    sparkSession.stop()
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
+    sparkSession = null
+
+    FileUtils.deleteDirectory(new File("spark-warehouse"))
+    super.afterAll()
+  }
+
+  test("INSERT INTO HIVE TABLE FROM HIVE TABLE") {
+    val qe = sparkSession.sql(s"INSERT INTO TABLE $destinationHiveTblName " +
+      s"SELECT * FROM $sourceHiveTblName").queryExecution
+    val qd = QueryDetail(qe, 0L, 0L)
+
+    assert(qe.sparkPlan.isInstanceOf[DataWritingCommandExec])
+    val node = qe.sparkPlan.asInstanceOf[DataWritingCommandExec]
+    assert(node.cmd.isInstanceOf[InsertIntoHiveTable])
+    val cmd = node.cmd.asInstanceOf[InsertIntoHiveTable]
+
+    val entities = CommandsHarvester.InsertIntoHiveTableHarvester.harvest(cmd, qd)
+    val pEntity = entities.head
+
+    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
+    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
+    inputs.size() should be (1)
+
+    val inputTbl = inputs.asScala.head
+    inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+    inputTbl.getAttribute("name") should be (sourceHiveTblName)
+    inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
+      s"default.$sourceHiveTblName@primary")
+
+    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
+    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
+    outputs.size() should be (1)
+    val outputTbl = outputs.asScala.head
+    outputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+    outputTbl.getAttribute("name") should be (destinationHiveTblName)
+    outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
+      s"default.$destinationHiveTblName@primary")
+  }
+
+  test("INSERT INTO HIVE TABLE FROM SPARK TABLE") {
+    val qe = sparkSession.sql(s"INSERT INTO TABLE $destinationHiveTblName " +
+      s"SELECT * FROM $sourceSparkTblName").queryExecution
+    val qd = QueryDetail(qe, 0L, 0L)
+
+    assert(qe.sparkPlan.isInstanceOf[DataWritingCommandExec])
+    val node = qe.sparkPlan.asInstanceOf[DataWritingCommandExec]
+    assert(node.cmd.isInstanceOf[InsertIntoHiveTable])
+    val cmd = node.cmd.asInstanceOf[InsertIntoHiveTable]
+
+    val entities = CommandsHarvester.InsertIntoHiveTableHarvester.harvest(cmd, qd)
+    val pEntity = entities.head
+
+    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
+    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
+    inputs.size() should be (1)
+
+    val inputTbl = inputs.asScala.head
+    inputTbl.getTypeName should not be external.HIVE_TABLE_TYPE_STRING
+    inputTbl.getAttribute("name") should be (sourceSparkTblName)
+    inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
+      s"default.$sourceSparkTblName")
+
+    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
+    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
+    outputs.size() should be (1)
+    val outputTbl = outputs.asScala.head
+    outputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+    outputTbl.getAttribute("name") should be (destinationHiveTblName)
+    outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
+      s"default.$destinationHiveTblName@primary")
+  }
+
+  test("INSERT INTO SPARK TABLE FROM HIVE TABLE") {
+    val qe = sparkSession.sql(s"INSERT INTO TABLE $destinationSparkTblName " +
+      s"SELECT * FROM $sourceHiveTblName").queryExecution
+    val qd = QueryDetail(qe, 0L, 0L)
+
+    assert(qe.sparkPlan.isInstanceOf[DataWritingCommandExec])
+    val node = qe.sparkPlan.asInstanceOf[DataWritingCommandExec]
+    assert(node.cmd.isInstanceOf[InsertIntoHadoopFsRelationCommand])
+    val cmd = node.cmd.asInstanceOf[InsertIntoHadoopFsRelationCommand]
+
+    val entities = CommandsHarvester.InsertIntoHadoopFsRelationHarvester.harvest(cmd, qd)
+    val pEntity = entities.head
+
+    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
+    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
+    inputs.size() should be (1)
+
+    val inputTbl = inputs.asScala.head
+    inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+    inputTbl.getAttribute("name") should be (sourceHiveTblName)
+    inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
+      s"default.$sourceHiveTblName@primary")
+
+    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
+    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
+    outputs.size() should be (1)
+    val outputTbl = outputs.asScala.head
+    outputTbl.getTypeName should not be external.HIVE_TABLE_TYPE_STRING
+    outputTbl.getAttribute("name") should be (destinationSparkTblName)
+    outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
+      s"default.$destinationSparkTblName")
+  }
+
+  test("INSERT INTO SPARK TABLE FROM SPARK TABLE") {
+    val qe = sparkSession.sql(s"INSERT INTO TABLE $destinationSparkTblName " +
+      s"SELECT * FROM $sourceSparkTblName").queryExecution
+    val qd = QueryDetail(qe, 0L, 0L)
+
+    assert(qe.sparkPlan.isInstanceOf[DataWritingCommandExec])
+    val node = qe.sparkPlan.asInstanceOf[DataWritingCommandExec]
+    assert(node.cmd.isInstanceOf[InsertIntoHadoopFsRelationCommand])
+    val cmd = node.cmd.asInstanceOf[InsertIntoHadoopFsRelationCommand]
+
+    val entities = CommandsHarvester.InsertIntoHadoopFsRelationHarvester.harvest(cmd, qd)
+    val pEntity = entities.head
+
+    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
+    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
+    inputs.size() should be (1)
+
+    val inputTbl = inputs.asScala.head
+    inputTbl.getTypeName should not be external.HIVE_TABLE_TYPE_STRING
+    inputTbl.getAttribute("name") should be (sourceSparkTblName)
+    inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
+      s"default.$sourceSparkTblName")
+
+    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
+    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
+    outputs.size() should be (1)
+    val outputTbl = outputs.asScala.head
+    outputTbl.getTypeName should not be external.HIVE_TABLE_TYPE_STRING
+    outputTbl.getAttribute("name") should be (destinationSparkTblName)
+    outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
+      s"default.$destinationSparkTblName")
+  }
+}

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
@@ -46,17 +46,17 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with BeforeAndAfte
     super.beforeAll()
     sparkSession = SparkSession.builder()
       .master("local")
-      .config("spark.sql.catalogImplementation", "hive")
+      .enableHiveSupport()
       .getOrCreate()
 
     sparkSession.sql(s"CREATE TABLE $sourceHiveTblName (name string)")
     sparkSession.sql(s"INSERT INTO TABLE $sourceHiveTblName VALUES ('a'), ('b'), ('c')")
 
-    sparkSession.sql(s"CREATE TABLE $sourceSparkTblName (name string) USING PARQUET")
+    sparkSession.sql(s"CREATE TABLE $sourceSparkTblName (name string) USING ORC")
     sparkSession.sql(s"INSERT INTO TABLE $sourceSparkTblName VALUES ('d'), ('e'), ('f')")
 
     sparkSession.sql(s"CREATE TABLE $destinationHiveTblName (name string)")
-    sparkSession.sql(s"CREATE TABLE $destinationSparkTblName (name string) USING PARQUET")
+    sparkSession.sql(s"CREATE TABLE $destinationSparkTblName (name string) USING ORC")
   }
 
   override def afterAll(): Unit = {

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
@@ -37,10 +37,10 @@ import com.hortonworks.spark.atlas.types.external
 class InsertIntoHarvesterSuite extends FunSuite with Matchers with BeforeAndAfterAll {
 
   private var sparkSession: SparkSession = _
-  private val sourceHiveTblName = "source_" + Random.nextInt(100000)
-  private val sourceSparkTblName = "source_" + Random.nextInt(100000)
-  private val destinationHiveTblName = "destination_" + Random.nextInt(100000)
-  private val destinationSparkTblName = "destination_" + Random.nextInt(100000)
+  private val sourceHiveTblName = "source_h_" + Random.nextInt(100000)
+  private val sourceSparkTblName = "source_s_" + Random.nextInt(100000)
+  private val destinationHiveTblName = "destination_h_" + Random.nextInt(100000)
+  private val destinationSparkTblName = "destination_s_" + Random.nextInt(100000)
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
@@ -65,7 +65,9 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with BeforeAndAfte
     SparkSession.clearDefaultSession()
     sparkSession = null
 
+    FileUtils.deleteDirectory(new File("metastore_db"))
     FileUtils.deleteDirectory(new File("spark-warehouse"))
+
     super.afterAll()
   }
 


### PR DESCRIPTION
Changes:
Merge code supporting "Insert Into" and "Create View xx As Select * From xx" into master branch. 

Testing:
New unit tests were added.
I manually tested this PR in HDP cluster:
Case1:
    sql("create table table_parquet_200 (a int) using parquet")
    sql("insert into  table table_parquet_200 values (200)")
    sql("create table table_parquet_300 (a int) using parquet")
    sql("INSERT INTO table_parquet_300  SELECT * FROM table_parquet_200")

Case2:
    sql("CREATE TABLE t00000(a int)")
    sql("INSERT INTO t00000 VALUES (1)")
    sql("CREATE TABLE t10000(a int)")
    sql("INSERT INTO t10000 SELECT * FROM t00000")

Case 3: 
sql("CREATE TABLE sourceTable(a int)")
sql("INSERT INTO sourceTable VALUES (1)")
sql("CREATE view s_view1 as select * from sourceTable")