### PR TITLE
InsertInto: support multiple source tables and destination tables

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanTracker.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanTracker.scala
@@ -66,7 +66,6 @@ class SparkExecutionPlanTracker(
     logWarn(s"Fail to execute query: {$qe}, {$funcName}", exception)
   }
 
-  // TODO: We should consider multiple inputs and multiple outs.
   // TODO: We should handle OVERWRITE to remove the old lineage.
   // TODO: We should consider LLAPRelation later
   override protected def eventProcess(): Unit = {
@@ -75,6 +74,7 @@ class SparkExecutionPlanTracker(
       try {
         Option(qeQueue.poll(3000, TimeUnit.MILLISECONDS)).foreach { qd =>
           val entities = qd.qe.sparkPlan.collect {
+            case p: UnionExec => p.children
             case p: DataWritingCommandExec => p
             case p: LeafExecNode => p
           }.flatMap {

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
@@ -52,7 +52,6 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with BeforeAndAfte
   private val outputTable3 = "output3_" + Random.nextInt(100000)
   private val outputTable4 = "output4_" + Random.nextInt(100000)
 
-
   override def beforeAll(): Unit = {
     super.beforeAll()
     sparkSession = SparkSession.builder()
@@ -84,7 +83,6 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with BeforeAndAfte
     sparkSession.sql(s"create table $outputTable2 (id int)")
     sparkSession.sql(s"create table $outputTable3 (code string)")
     sparkSession.sql(s"create table $outputTable4 (salary int)")
-
   }
 
   override def afterAll(): Unit = {
@@ -274,7 +272,7 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with BeforeAndAfte
 
     assert(qe.sparkPlan.isInstanceOf[UnionExec])
     qe.sparkPlan.asInstanceOf[UnionExec]
-      qe.sparkPlan.children.foreach(child => {
+    qe.sparkPlan.children.foreach(child => {
       assert(child.isInstanceOf[DataWritingCommandExec])
       val node = child.asInstanceOf[DataWritingCommandExec]
       assert(node.cmd.isInstanceOf[InsertIntoHiveTable])

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
@@ -28,6 +28,7 @@ import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
+import org.apache.spark.sql.execution.UnionExec
 import org.apache.spark.sql.hive.execution.InsertIntoHiveTable
 import org.apache.spark.sql.SparkSession
 import org.scalatest.{BeforeAndAfterAll, Matchers, FunSuite}
@@ -41,6 +42,16 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with BeforeAndAfte
   private val sourceSparkTblName = "source_s_" + Random.nextInt(100000)
   private val destinationHiveTblName = "destination_h_" + Random.nextInt(100000)
   private val destinationSparkTblName = "destination_s_" + Random.nextInt(100000)
+
+  private val inputTable1 = "input1_" + Random.nextInt(100000)
+  private val inputTable2 = "input2_" + Random.nextInt(100000)
+  private val inputTable3 = "input3_" + Random.nextInt(100000)
+  private val inputTable4 = "input4_" + Random.nextInt(100000)
+  private val outputTable1 = "output1_" + Random.nextInt(100000)
+  private val outputTable2 = "output2_" + Random.nextInt(100000)
+  private val outputTable3 = "output3_" + Random.nextInt(100000)
+  private val outputTable4 = "output4_" + Random.nextInt(100000)
+
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -57,6 +68,23 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with BeforeAndAfte
 
     sparkSession.sql(s"CREATE TABLE $destinationHiveTblName (name string)")
     sparkSession.sql(s"CREATE TABLE $destinationSparkTblName (name string) USING ORC")
+
+    // multiple source tables
+    sparkSession.sql(s"CREATE TABLE $inputTable1 (a int, b string)")
+    sparkSession.sql(s"INSERT INTO $inputTable1 VALUES(1, 'str1')")
+    sparkSession.sql(s"CREATE TABLE $inputTable2 (c int, d string)")
+    sparkSession.sql(s"INSERT INTO $inputTable2 VALUES(1, 'str2')")
+    sparkSession.sql(s"CREATE TABLE $inputTable3 (e int, f string)")
+    sparkSession.sql(s"INSERT INTO $inputTable3 VALUES(1, 'str3')")
+    sparkSession.sql(s"CREATE TABLE $outputTable1 (a int, b string, c int, d string, e int, f string)")
+
+    // multiple destination tables
+    sparkSession.sql(s"create table $inputTable4 (id int, code string, salary int)")
+    sparkSession.sql(s"INSERT INTO $inputTable4 VALUES(1, 'hihi', 100)")
+    sparkSession.sql(s"create table $outputTable2 (id int)")
+    sparkSession.sql(s"create table $outputTable3 (code string)")
+    sparkSession.sql(s"create table $outputTable4 (salary int)")
+
   }
 
   override def afterAll(): Unit = {
@@ -201,5 +229,78 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with BeforeAndAfte
     outputTbl.getAttribute("name") should be (destinationSparkTblName)
     outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
       s"default.$destinationSparkTblName")
+  }
+
+  test("INSERT INTO TABLE FROM MULTIPLE TABLES") {
+    val qe = sparkSession.sql(s"INSERT INTO $outputTable1 " +
+      s"SELECT * FROM $inputTable1, $inputTable2, $inputTable3 " +
+      s"where $inputTable1.a = $inputTable2.c AND $inputTable1.a = $inputTable3.e").queryExecution
+    val qd = QueryDetail(qe, 0L, 0L)
+
+    assert(qe.sparkPlan.isInstanceOf[DataWritingCommandExec])
+    val node = qe.sparkPlan.asInstanceOf[DataWritingCommandExec]
+    assert(node.cmd.isInstanceOf[InsertIntoHiveTable])
+    val cmd = node.cmd.asInstanceOf[InsertIntoHiveTable]
+
+    val entities = CommandsHarvester.InsertIntoHiveTableHarvester.harvest(cmd, qd)
+    val pEntity = entities.head
+
+    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
+    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
+    inputs.size() should be (3)
+
+    val inputTbl = inputs.asScala.head
+    inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+    inputTbl.getAttribute("name").toString should startWith ("input")
+    inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should startWith (
+      "default.input")
+
+    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
+    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
+    outputs.size() should be (1)
+    val outputTbl = outputs.asScala.head
+    outputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+    outputTbl.getAttribute("name") should be (outputTable1)
+    outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
+      s"default.$outputTable1@primary")
+  }
+
+  test("INSERT INTO MULTIPLE TABLES FROM TABLE") {
+    val qe = sparkSession.sql(s"FROM $inputTable4 " +
+      s"INSERT INTO TABLE $outputTable2 SELECT $inputTable4.id " +
+      s"INSERT INTO TABLE $outputTable3 SELECT $inputTable4.code " +
+      s"INSERT into TABLE $outputTable4 SELECT $inputTable4.salary").queryExecution
+    val qd = QueryDetail(qe, 0L, 0L)
+
+    assert(qe.sparkPlan.isInstanceOf[UnionExec])
+    qe.sparkPlan.asInstanceOf[UnionExec]
+      qe.sparkPlan.children.foreach(child => {
+      assert(child.isInstanceOf[DataWritingCommandExec])
+      val node = child.asInstanceOf[DataWritingCommandExec]
+      assert(node.cmd.isInstanceOf[InsertIntoHiveTable])
+      val cmd = node.cmd.asInstanceOf[InsertIntoHiveTable]
+
+      val entities = CommandsHarvester.InsertIntoHiveTableHarvester.harvest(cmd, qd)
+      val pEntity = entities.head
+
+      assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
+      val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
+      inputs.size() should be (1)
+
+      val inputTbl = inputs.asScala.head
+      inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+      inputTbl.getAttribute("name") should be (inputTable4)
+      inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
+        s"default.$inputTable4@primary")
+
+      assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
+      val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
+      outputs.size() should be (1)
+      val outputTbl = outputs.asScala.head
+      outputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+      outputTbl.getAttribute("name").toString should startWith ("output")
+      outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should startWith (
+        "default.output")
+    })
   }
 }


### PR DESCRIPTION
Changes:
Added supports for multiple source tables and destination tables ( `InsertInto` queries). 

Tests:
New unit tests were added.
Manually tested in HDP cluster.

Case1: multiple source tables
```
sql(s"CREATE TABLE inputTable1 (a int, b string)")
sql(s"INSERT INTO inputTable1 VALUES(1, 'str1')")
sql(s"CREATE TABLE inputTable2 (c int, d string)")
sql(s"INSERT INTO inputTable2 VALUES(1, 'str2')")
sql(s"CREATE TABLE inputTable3 (e int, f string)")
sql(s"INSERT INTO inputTable3 VALUES(1, 'str3')")
sql(s"CREATE TABLE outputTable1 (a int, b string, c int, d string, e int, f string)")
sql("INSERT INTO outputTable1 " +
      "SELECT * FROM inputTable1, inputTable2, inputTable3 " +
      "where inputTable1.a = inputTable2.c AND inputTable1.a = inputTable3.e")
```

Case2: multiple destination tables
```
sql(s"create table inputTable4 (id int, code string, salary int)")
    sql(s"INSERT INTO inputTable4 VALUES(1, 'hihi', 100)")
    sql(s"create table outputTable2 (id int)")
    sql(s"create table outputTable3 (code string)")
    sql(s"create table outputTable4 (salary int)")
    sql(s"FROM inputTable4 " +
      s"INSERT INTO TABLE outputTable2 SELECT inputTable4.id " +
      s"INSERT INTO TABLE outputTable3 SELECT inputTable4.code " +
      s"INSERT into TABLE outputTable4 SELECT inputTable4.salary")
```