### PR TITLE
[SAC-13] Support hdfs data source

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -69,15 +69,11 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       val inputsEntities = tChildren.map {
         case r: HiveTableRelation => tableToEntities(r.tableMeta)
         case v: View => tableToEntities(v.desc)
-        case l: LogicalRelation =>
-          if (l.catalogTable.isDefined)
-            l.catalogTable.map(tableToEntities(_)).get
-          else {
-            l.relation match {
-              case r: FileRelation => r.inputFiles.map(external.pathToEntity).toSeq
-              case _ => Seq.empty
-            }
-          }
+        case l: LogicalRelation if l.catalogTable.isDefined => l.catalogTable.map(tableToEntities(_)).get
+        case l: LogicalRelation => l.relation match {
+                  case r: FileRelation => r.inputFiles.map(external.pathToEntity).toSeq
+                  case _ => Seq.empty
+                }
         case e =>
           logWarn(s"Missing unknown leaf node: $e")
           Seq.empty

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -70,8 +70,14 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
         case r: HiveTableRelation => tableToEntities(r.tableMeta)
         case v: View => tableToEntities(v.desc)
         case l: LogicalRelation =>
-          l.catalogTable.map(tableToEntities(_)).getOrElse(
-            l.relation.asInstanceOf[FileRelation].inputFiles.map(external.pathToEntity).toSeq)
+          if (l.catalogTable.isDefined)
+            l.catalogTable.map(tableToEntities(_)).get
+          else {
+            l.relation match {
+              case r: FileRelation => r.inputFiles.map(external.pathToEntity).toSeq
+              case _ => Seq.empty
+            }
+          }
         case e =>
           logWarn(s"Missing unknown leaf node: $e")
           Seq.empty

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -69,11 +69,12 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       val inputsEntities = tChildren.map {
         case r: HiveTableRelation => tableToEntities(r.tableMeta)
         case v: View => tableToEntities(v.desc)
-        case l: LogicalRelation if l.catalogTable.isDefined => l.catalogTable.map(tableToEntities(_)).get
+        case l: LogicalRelation if l.catalogTable.isDefined =>
+          l.catalogTable.map(tableToEntities(_)).get
         case l: LogicalRelation => l.relation match {
-                  case r: FileRelation => r.inputFiles.map(external.pathToEntity).toSeq
-                  case _ => Seq.empty
-                }
+          case r: FileRelation => r.inputFiles.map(external.pathToEntity).toSeq
+          case _ => Seq.empty
+        }
         case e =>
           logWarn(s"Missing unknown leaf node: $e")
           Seq.empty


### PR DESCRIPTION
Changes: 
Support hdfs data source.

Tests:
Manually tested in HDFS cluster.

Case1:
```
spark.read.orc("/tmp/users.orc").write.save("/tmp/users0.orc")
```
Case2:
```
spark.read.json("/tmp/people.json").write.save("/tmp/people0.json")
```
