### PR TITLE
Fix CreateHiveTableAsSelectHarvesterSuite failure

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanTracker.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanTracker.scala
@@ -86,11 +86,6 @@ class SparkExecutionPlanTracker(
                   logDebug(s"LOAD DATA [LOCAL] INPATH (${c.path}) ${c.table}")
                   CommandsHarvester.LoadDataHarvester.harvest(c, qd)
 
-                // Case 6. CREATE TABLE AS SELECT
-                case c: CreateHiveTableAsSelectCommand =>
-                  logDebug(s"CREATE TABLE AS SELECT query: ${qd.qe}")
-                  CommandsHarvester.CreateHiveTableAsSelectHarvester.harvest(c, qd)
-
                 case c: CreateDataSourceTableAsSelectCommand =>
                   logDebug(s"CREATE TABLE USING xx AS SELECT query: ${qd.qe}")
                   CommandsHarvester.CreateDataSourceTableAsSelectHarvester.harvest(c, qd)
@@ -112,6 +107,11 @@ class SparkExecutionPlanTracker(
                 case c: InsertIntoHadoopFsRelationCommand =>
                   logDebug(s"INSERT INTO SPARK TABLE query ${qd.qe}")
                   CommandsHarvester.InsertIntoHadoopFsRelationHarvester.harvest(c, qd)
+
+                // Case 6. CREATE TABLE AS SELECT
+                case c: CreateHiveTableAsSelectCommand =>
+                  logDebug(s"CREATE TABLE AS SELECT query: ${qd.qe}")
+                  CommandsHarvester.CreateHiveTableAsSelectHarvester.harvest(c, qd)
 
                 case _ =>
                   Seq.empty

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateHiveTableAsSelectHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateHiveTableAsSelectHarvesterSuite.scala
@@ -28,7 +28,7 @@ import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.LeafExecNode
-import org.apache.spark.sql.execution.command.ExecutedCommandExec
+import org.apache.spark.sql.execution.command.DataWritingCommandExec
 import org.apache.spark.sql.hive.execution.CreateHiveTableAsSelectCommand
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
 
@@ -71,10 +71,11 @@ class CreateHiveTableAsSelectHarvesterSuite extends FunSuite with Matchers with 
       .queryExecution
     val qd = QueryDetail(qe, 0L, 0L)
     val ctasNode = qe.sparkPlan.collect {
+      case p: DataWritingCommandExec => p
       case p: LeafExecNode => p
     }
-    assert(ctasNode.size === 1)
-    val execNode = ctasNode.head.asInstanceOf[ExecutedCommandExec]
+    assert(ctasNode.size === 2)
+    val execNode = ctasNode.head.asInstanceOf[DataWritingCommandExec]
 
     val entities = CommandsHarvester.CreateHiveTableAsSelectHarvester.harvest(
       execNode.cmd.asInstanceOf[CreateHiveTableAsSelectCommand], qd)
@@ -110,10 +111,11 @@ class CreateHiveTableAsSelectHarvesterSuite extends FunSuite with Matchers with 
       .queryExecution
     val qd = QueryDetail(qe, 0L, 0L)
     val ctasNode = qe.sparkPlan.collect {
+      case p: DataWritingCommandExec => p
       case p: LeafExecNode => p
     }
-    assert(ctasNode.size === 1)
-    val execNode = ctasNode.head.asInstanceOf[ExecutedCommandExec]
+    assert(ctasNode.size === 3)
+    val execNode = ctasNode.head.asInstanceOf[DataWritingCommandExec]
 
     val entities = CommandsHarvester.CreateHiveTableAsSelectHarvester.harvest(
       execNode.cmd.asInstanceOf[CreateHiveTableAsSelectCommand], qd)
@@ -147,10 +149,11 @@ class CreateHiveTableAsSelectHarvesterSuite extends FunSuite with Matchers with 
       .queryExecution
     val qd = QueryDetail(qe, 0L, 0L)
     val ctasNode = qe.sparkPlan.collect {
+      case p: DataWritingCommandExec => p
       case p: LeafExecNode => p
     }
-    assert(ctasNode.size === 1)
-    val execNode = ctasNode.head.asInstanceOf[ExecutedCommandExec]
+    assert(ctasNode.size === 2)
+    val execNode = ctasNode.head.asInstanceOf[DataWritingCommandExec]
 
     val entities = CommandsHarvester.CreateHiveTableAsSelectHarvester.harvest(
       execNode.cmd.asInstanceOf[CreateHiveTableAsSelectCommand], qd)
@@ -184,10 +187,11 @@ class CreateHiveTableAsSelectHarvesterSuite extends FunSuite with Matchers with 
       s"FROM parquet.`$path`").queryExecution
     val qd = QueryDetail(qe, 0L, 0L)
     val ctasNode = qe.sparkPlan.collect {
+      case p: DataWritingCommandExec => p
       case p: LeafExecNode => p
     }
-    assert(ctasNode.size === 1)
-    val execNode = ctasNode.head.asInstanceOf[ExecutedCommandExec]
+    assert(ctasNode.size === 2)
+    val execNode = ctasNode.head.asInstanceOf[DataWritingCommandExec]
 
     val entities = CommandsHarvester.CreateHiveTableAsSelectHarvester.harvest(
       execNode.cmd.asInstanceOf[CreateHiveTableAsSelectCommand], qd)


### PR DESCRIPTION
Change:
CreateHiveTableAsSelectHarvesterSuite failed because of some changes happened in Spark 2.3.1 branch.

Testing:
Pass the current unit tests.