### PR TITLE
[SAC-13] Support KafKa data source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,13 @@
 
     <dependency>
       <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql-kafka-0-10_${scala.binary.version}</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.spark</groupId>
       <artifactId>spark-hive_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -129,7 +129,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
               val tableMeta = map.get("table").get.asInstanceOf[Map[String, _]]
               val nSpace = tableMeta.getOrElse("namespace", "default").asInstanceOf[String]
               val tName = tableMeta.get("name").get.asInstanceOf[String]
-              external.hbaseTableToEntity(conf.get(AtlasClientConf.CLUSTER_NAME), tName, nSpace)
+              external.hbaseTableToEntity(clusterName, tName, nSpace)
             } else {
               logWarn(s"Class $maybeClazz is not found")
               Seq.empty

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventTracker.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventTracker.scala
@@ -45,6 +45,8 @@ class SparkCatalogEventTracker(
     this(new AtlasClientConf)
   }
 
+  println("---SparkCatalogEventTracker new----")
+
   private val capacity = conf.get(AtlasClientConf.BLOCKING_QUEUE_CAPACITY).toInt
 
   // A blocking queue for Spark Listener ExternalCatalog related events.

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventTracker.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventTracker.scala
@@ -45,8 +45,6 @@ class SparkCatalogEventTracker(
     this(new AtlasClientConf)
   }
 
-  println("---SparkCatalogEventTracker new----")
-
   private val capacity = conf.get(AtlasClientConf.BLOCKING_QUEUE_CAPACITY).toInt
 
   // A blocking queue for Spark Listener ExternalCatalog related events.

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanTracker.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanTracker.scala
@@ -28,8 +28,12 @@ import org.json4s.jackson.JsonMethods._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.execution.datasources.{SaveIntoDataSourceCommand, InsertIntoHadoopFsRelationCommand}
+import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec
+import org.apache.spark.sql.execution.streaming.sources.InternalRowMicroBatchWriter
 import org.apache.spark.sql.hive.execution._
 import org.apache.spark.sql.util.QueryExecutionListener
+import org.apache.spark.sql.kafka010.KafkaStreamWriter
+import org.apache.spark.sql.kafka010.atlas.KafkaHarvester
 
 import com.hortonworks.spark.atlas.{AtlasClient, AtlasClientConf}
 import com.hortonworks.spark.atlas.types.external
@@ -49,7 +53,7 @@ class SparkExecutionPlanTracker(
   def this() {
     this(new AtlasClientConf)
   }
-
+  println("---SparkExecutionPlanTracker new----")
   private val capacity = conf.get(AtlasClientConf.BLOCKING_QUEUE_CAPACITY).toInt
   // A blocking queue for various query executions
   private val qeQueue = new LinkedBlockingQueue[QueryDetail](capacity)
@@ -80,6 +84,7 @@ class SparkExecutionPlanTracker(
           val entities = qd.qe.sparkPlan.collect {
             case p: UnionExec => p.children
             case p: DataWritingCommandExec => p
+            case p: WriteToDataSourceV2Exec => p
             case p: LeafExecNode => p
           }.flatMap {
             case r: ExecutedCommandExec =>
@@ -128,10 +133,33 @@ class SparkExecutionPlanTracker(
                   logDebug(s"INSERT INTO SPARK TABLE query ${qd.qe}")
                   CommandsHarvester.InsertIntoHadoopFsRelationHarvester.harvest(c, qd)
 
-                // Case 6. CREATE TABLE AS SELECT
                 case c: CreateHiveTableAsSelectCommand =>
                   logDebug(s"CREATE TABLE AS SELECT query: ${qd.qe}")
                   CommandsHarvester.CreateHiveTableAsSelectHarvester.harvest(c, qd)
+
+                case _ =>
+                  Seq.empty
+              }
+
+            case r: WriteToDataSourceV2Exec =>
+              println("-----WriteToDataSourceV2Exec-------")
+              r.writer match {
+                case w: InternalRowMicroBatchWriter =>
+                  println("-----InternalRowMicroBatchWriter-------")
+                  try {
+                    val streamWriter = w.getClass.getMethod("writer").invoke(w)
+                    streamWriter match {
+                      case sw: KafkaStreamWriter =>
+                        println("-----KafkaStreamWriter-------")
+                        KafkaHarvester.harvest(sw, r, qd)
+                      case _ => Seq.empty
+                    }
+                  }catch {
+                      case e: NoSuchMethodException =>
+                        println("-----WriteToDataSourceV2Exec NoSuchMethodException-------")
+                        logDebug(s"Can not get KafkaStreamWriter, so can not create Kafka topic entities: ${qd.qe}")
+                        Seq.empty
+                  }
 
                 case _ =>
                   Seq.empty

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanTracker.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanTracker.scala
@@ -30,9 +30,9 @@ import org.apache.spark.sql.execution.datasources.{SaveIntoDataSourceCommand, In
 import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec
 import org.apache.spark.sql.execution.streaming.sources.InternalRowMicroBatchWriter
 import org.apache.spark.sql.hive.execution._
-import org.apache.spark.sql.util.QueryExecutionListener
 import org.apache.spark.sql.kafka010.KafkaStreamWriter
 import org.apache.spark.sql.kafka010.atlas.KafkaHarvester
+import org.apache.spark.sql.util.QueryExecutionListener
 
 import com.hortonworks.spark.atlas.{AtlasClient, AtlasClientConf}
 import com.hortonworks.spark.atlas.types.external

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -100,7 +100,6 @@ object external {
   val KAFKA_TOPIC_STRING = "kafka_topic"
 
   def kafkaToEntity(cluster: String, topicName: String): Seq[AtlasEntity] = {
-    println("---kafkaToEntity----")
     val kafkaEntity = new AtlasEntity(KAFKA_TOPIC_STRING)
     kafkaEntity.setAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME,
       topicName.toLowerCase + '@' + cluster)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -96,6 +96,21 @@ object external {
     Seq(hbaseEntity)
   }
 
+  // ================ Kafka entities =======================
+  val KAFKA_TOPIC_STRING = "kafka_topic"
+
+  def kafkaToEntity(cluster: String, topicName: String): Seq[AtlasEntity] = {
+    println("---kafkaToEntity----")
+    val kafkaEntity = new AtlasEntity(KAFKA_TOPIC_STRING)
+    kafkaEntity.setAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME,
+      topicName.toLowerCase + '@' + cluster)
+    kafkaEntity.setAttribute(AtlasClient.NAME, topicName.toLowerCase)
+    kafkaEntity.setAttribute(AtlasConstants.CLUSTER_NAME_ATTRIBUTE, cluster)
+    kafkaEntity.setAttribute("uri", topicName.toLowerCase)
+    kafkaEntity.setAttribute("topic", topicName.toLowerCase)
+    Seq(kafkaEntity)
+  }
+
   // ================== Hive entities =====================
   val HIVE_DB_TYPE_STRING = "hive_db"
   val HIVE_STORAGEDESC_TYPE_STRING = "hive_storagedesc"

--- a/spark-atlas-connector/src/main/scala/org/apache/spark/sql/kafka010/atlas/KafkaHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/org/apache/spark/sql/kafka010/atlas/KafkaHarvester.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kafka010.atlas
+
+import org.apache.atlas.model.instance.AtlasEntity
+import org.apache.spark.sql.execution.RDDScanExec
+import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec
+import org.apache.spark.sql.kafka010.{KafkaSourceRDDPartition, KafkaStreamWriter}
+
+import com.hortonworks.spark.atlas.AtlasClientConf
+import com.hortonworks.spark.atlas.sql.QueryDetail
+import com.hortonworks.spark.atlas.types.{AtlasEntityUtils, external}
+import com.hortonworks.spark.atlas.utils.Logging
+
+object KafkaHarvester extends AtlasEntityUtils with Logging {
+  override val conf: AtlasClientConf = new AtlasClientConf
+
+  def harvest(node: KafkaStreamWriter, writer: WriteToDataSourceV2Exec,
+    qd: QueryDetail) : Seq[AtlasEntity] = {
+    // source topic
+    val tChildren = writer.query.collectLeaves()
+    val inputsEntities = tChildren.flatMap{
+      case r: RDDScanExec =>
+        r.rdd.partitions.map {
+          case e: KafkaSourceRDDPartition =>
+            println("-----KafkaSourceRDDPartition -------")
+            external.kafkaToEntity(clusterName, e.offsetRange.topic)
+        }.toSeq.flatten
+    }
+
+    // destination topic
+    var topic = None: Option[String]
+    try {
+      topic = node.getClass.getMethod("topic").invoke(node).asInstanceOf[Option[String]]
+    } catch {
+      case e: NoSuchMethodException =>
+        println("-----KafkaHarvester NoSuchMethodException-------" + node.getClass)
+        println(s"Can not get topic, so can not create Kafka topic entities: ${qd.qe}")
+        logDebug(s"Can not get topic, so can not create Kafka topic entities: ${qd.qe}")
+    }
+    val outputEntities = if (topic.isDefined) external.kafkaToEntity(clusterName, topic.get) else Seq.empty
+
+    // create process entity
+    val inputTablesEntities = inputsEntities.toList
+    val outputTableEntities = outputEntities.toList
+    val pEntity = processToEntity(
+      qd.qe, qd.executionId, qd.executionTime, inputTablesEntities, outputTableEntities)
+    Seq(pEntity) ++ inputsEntities ++ outputEntities
+  }
+
+}


### PR DESCRIPTION
Changes:
1. If users wants to use this feature, their spark needs to backport this PR: https://github.com/hortonworks/spark2/pull/5

2. Add KafkaHarveste to create kafka_topic entities.

Testing:
In spark-shell:

```
// read from 3 topics: 'spark2', 'spark3', and 'sparkmore'
val df = spark.readStream.format("kafka").option("kafka.bootstrap.servers", "localhost:9092").option("subscribe", "spark2,spark3,sparkmore").option("startingOffsets", "earliest").load()
//write into the topic 'spark6':
df.writeStream.format("kafka").option("kafka.bootstrap.servers", "localhost:9092").option("checkpointLocation", "/tmp/mykafka").option("topic", "spark6").start()
```
Result in Atlas:
<img width="651" alt="screen shot 2018-03-02 at 8 46 21 pm" src="https://user-images.githubusercontent.com/8546874/36930663-d24c020e-1e5a-11e8-9a6e-bd61968e5d1f.png">

