### PR TITLE
[SAC-27]Fix Issues of Support Multiple Input Files (InsertInto)

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -80,15 +80,18 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
     override def harvest(node: InsertIntoHadoopFsRelationCommand, qd: QueryDetail): Seq[AtlasEntity] = {
       // source tables/files entities
       val tChildren = node.query.collectLeaves()
+      var isFiles = false
       val inputsEntities = tChildren.map {
         case r: HiveTableRelation => tableToEntities(r.tableMeta)
         case v: View => tableToEntities(v.desc)
         case l: LogicalRelation if l.catalogTable.isDefined =>
           l.catalogTable.map(tableToEntities(_)).get
-        case l: LogicalRelation => l.relation match {
-          case r: FileRelation => r.inputFiles.map(external.pathToEntity).toSeq
-          case _ => Seq.empty
-        }
+        case l: LogicalRelation =>
+          isFiles = true
+          l.relation match {
+            case r: FileRelation => r.inputFiles.map(external.pathToEntity).toSeq
+            case _ => Seq.empty
+          }
         case e =>
           logWarn(s"Missing unknown leaf node: $e")
           Seq.empty
@@ -99,7 +102,8 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
         List(external.pathToEntity(node.outputPath.toUri.toString)))
 
       // create process entity
-      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
+      val inputTablesEntities = if (isFiles) inputsEntities.flatten.toList
+        else inputsEntities.flatMap(_.headOption).toList
       val outputTableEntities = List(outputEntities.head)
       val pEntity = processToEntity(
         qd.qe, qd.executionId, qd.executionTime, inputTablesEntities, outputTableEntities)


### PR DESCRIPTION
This PR is to fix a bug of supporting multiple input hdfs files. 

Testing:
In spark-shell:
```
case 1:
val df = spark.read.load("/tmp/parfile/users.parquet")
df.write.mode("overwrite").save("/tmp/outfile1.parquet")

case 2:
val df = spark.read.load("/tmp/parfile/allFilesAreParquet/")
df.write.mode("overwrite").save("/tmp/outfile2.parquet")

case 3:
val df = spark.read.load("/tmp/parfile/*.parquet")
df.write.mode("overwrite").save("/tmp/outfile3.parquet")
```
Results without this PR:
For these three cases, their lineages shown in Atlas have only one input entity (just like the picture for case 1 below).

Results with this PR in Atlas:
Case 1:
<img width="472" alt="screen shot 2018-03-03 at 9 31 59 am" src="https://user-images.githubusercontent.com/8546874/36937319-467bf010-1ec6-11e8-8bd9-f439dcff0c96.png">

Case 2:
<img width="628" alt="screen shot 2018-03-03 at 9 32 24 am" src="https://user-images.githubusercontent.com/8546874/36937313-36c0adfa-1ec6-11e8-9489-7ca09ed0c712.png">

Case 3:
<img width="507" alt="screen shot 2018-03-03 at 9 32 49 am" src="https://user-images.githubusercontent.com/8546874/36937307-31cd2efe-1ec6-11e8-9489-6ff9e8dc1de3.png">



