### PR TITLE
[SAC-33] Support HBase entities both as an input and an output

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanTracker.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanTracker.scala
@@ -22,8 +22,6 @@ import java.util.concurrent.atomic.AtomicLong
 
 import scala.util.control.NonFatal
 
-import org.json4s.JsonAST.JObject
-import org.json4s.jackson.JsonMethods._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.execution.datasources.{SaveIntoDataSourceCommand, InsertIntoHadoopFsRelationCommand}
@@ -35,7 +33,6 @@ import org.apache.spark.sql.kafka010.atlas.KafkaHarvester
 import org.apache.spark.sql.util.QueryExecutionListener
 
 import com.hortonworks.spark.atlas.{AtlasClient, AtlasClientConf}
-import com.hortonworks.spark.atlas.types.external
 import com.hortonworks.spark.atlas.utils.Logging
 
 case class QueryDetail(qe: QueryExecution, executionId: Long, executionTime: Long)
@@ -104,19 +101,7 @@ class SparkExecutionPlanTracker(
 
                 case c: SaveIntoDataSourceCommand =>
                   logDebug(s"DATA FRAME SAVE INTO DATA SOURCE: ${qd.qe}")
-                  // support SHC
-                  var catalog = ""
-                  c.options.foreach {x => if (x._1.equals("catalog")) catalog = x._2}
-                  if (catalog != "") {
-                    val jObj = parse(catalog).asInstanceOf[JObject]
-                    val map = jObj.values
-                    val tableMeta = map.get("table").get.asInstanceOf[Map[String, _]]
-                    val nSpace = tableMeta.getOrElse("namespace", "default").asInstanceOf[String]
-                    val tName = tableMeta.get("name").get.asInstanceOf[String]
-                    external.hbaseTableToEntity(conf.get(AtlasClientConf.CLUSTER_NAME), tName, nSpace)
-                  } else {
-                    Seq.empty
-                  }
+                  CommandsHarvester.SaveIntoDataSourceHarvester.harvest(c, qd)
 
                 case _ =>
                   Seq.empty

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -89,7 +89,7 @@ object external {
   def hbaseTableToEntity(cluster: String, tableName: String, nameSpace: String): Seq[AtlasEntity] = {
     val hbaseEntity = new AtlasEntity(HBASE_TABLE_STRING)
     hbaseEntity.setAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME,
-      getTableQualifiedName(cluster, tableName, nameSpace))
+      getTableQualifiedName(cluster, nameSpace, tableName))
     hbaseEntity.setAttribute(AtlasClient.NAME, tableName.toLowerCase)
     hbaseEntity.setAttribute(AtlasConstants.CLUSTER_NAME_ATTRIBUTE, cluster)
     hbaseEntity.setAttribute("uri", nameSpace.toLowerCase + ":" + tableName.toLowerCase)


### PR DESCRIPTION
Changes:
1. Fix a bug about the parameters' positions of `getTableQualifiedName(cluster, nameSpace, tableName)` function.
2. Fix a bug about missing passing SQL query as parameter when creating spark_process entity for some harvesters, e.g. `InsertIntoHiveTableHarvester` and `InsertIntoHadoopFsRelationHarvester`.
3. Support more SHC cases. Before this PR, SAC creates spark_process only when HBase table is the input. Now, with this PR, it can create spark_processes which use HBase entity as both the input and the output.

Testing:
Manually tested in HDP cluster:
HBase tables: t_demo_in200 (as input), t_demo_o200(as output)
Hive table: demo_table_shc200 (as output)(df.write.format("hive").mode(SaveMode.Append).saveAsTable("demo_table_shc200"))

Case 1: Hbase table "t_demo_in200" is the input, Hbase table t_demo_o200 is the output
<img width="578" alt="screen shot 2018-03-07 at 2 50 46 pm" src="https://user-images.githubusercontent.com/8546874/37122966-575d9ef2-2217-11e8-86e6-5ae92a083f86.png">
<img width="504" alt="screen shot 2018-03-07 at 3 00 17 pm" src="https://user-images.githubusercontent.com/8546874/37123240-490da2c4-2218-11e8-9f92-6a198bdb3366.png">


Case 2: Hbase table "t_demo_in200" is the input, Hive table demo_table_shc200 is the output
<img width="637" alt="screen shot 2018-03-07 at 2 55 28 pm" src="https://user-images.githubusercontent.com/8546874/37123034-9d4ffbf8-2217-11e8-9d35-26059717b8eb.png">
