### PR TITLE
[SAC-38] Fix issues to support sql queries shown in Atlas UI

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -73,7 +73,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
       val outputTableEntities = List(outputEntities.head)
       val pEntity = processToEntity(qd.qe, qd.executionId, qd.executionTime, inputTablesEntities,
-        outputTableEntities, Option(SQLQuery.get()))
+        outputTableEntities, qd.query)
       Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
     }
   }
@@ -109,7 +109,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
         else inputsEntities.flatMap(_.headOption).toList
       val outputTableEntities = List(outputEntities.head)
       val pEntity = processToEntity(qd.qe, qd.executionId, qd.executionTime, inputTablesEntities,
-        outputTableEntities, Option(SQLQuery.get()))
+        outputTableEntities, qd.query)
       Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
     }
   }
@@ -143,7 +143,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
       val outputTableEntities = List(outputEntities.head)
       val pEntity = processToEntity(qd.qe, qd.executionId, qd.executionTime, inputTablesEntities,
-        outputTableEntities, Option(SQLQuery.get()))
+        outputTableEntities, qd.query)
       Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
     }
   }
@@ -169,7 +169,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
       val outputTableEntities = List(outputEntities.head)
       val pEntity = processToEntity(qd.qe, qd.executionId, qd.executionTime, inputTablesEntities,
-        outputTableEntities, Option(SQLQuery.get()))
+        outputTableEntities, qd.query)
 
       Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
     }
@@ -180,7 +180,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       val pathEntity = external.pathToEntity(node.path)
       val outputEntities = prepareEntities(node.table)
       val pEntity = processToEntity(qd.qe, qd.executionId, qd.executionTime, List(pathEntity),
-        List(outputEntities.head), Option(SQLQuery.get()))
+        List(outputEntities.head), qd.query)
       Seq(pEntity, pathEntity) ++ outputEntities
     }
   }
@@ -211,7 +211,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
 
       val inputs = inputsEntities.flatMap(_.headOption).toList
       val pEntity = processToEntity(
-        qd.qe, qd.executionId, qd.executionTime, inputs, List(destEntity), Option(SQLQuery.get()))
+        qd.qe, qd.executionId, qd.executionTime, inputs, List(destEntity), qd.query)
       Seq(pEntity, destEntity) ++ inputsEntities.flatten
     }
   }
@@ -231,7 +231,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       val inputTableEntity = List(inputEntities.head)
       val outputTableEntity = List(outputEntities.head)
       val pEntity = processToEntity(qd.qe, qd.executionId, qd.executionTime, inputTableEntity,
-        outputTableEntity, Option(SQLQuery.get()))
+        outputTableEntity, qd.query)
 
       Seq(pEntity) ++ inputEntities ++ outputEntities
     }
@@ -280,7 +280,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
       val outputTableEntities = outputEntities.toList
       val pEntity = processToEntity(qd.qe, qd.executionId, qd.executionTime, inputTablesEntities,
-        outputTableEntities, Option(SQLQuery.get()))
+        outputTableEntities, qd.query)
       Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
     }
   }

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanTracker.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanTracker.scala
@@ -35,7 +35,8 @@ import org.apache.spark.sql.util.QueryExecutionListener
 import com.hortonworks.spark.atlas.{AtlasClient, AtlasClientConf}
 import com.hortonworks.spark.atlas.utils.Logging
 
-case class QueryDetail(qe: QueryExecution, executionId: Long, executionTime: Long)
+case class QueryDetail(qe: QueryExecution, executionId: Long,
+  executionTime: Long, query: Option[String] = None)
 
 class SparkExecutionPlanTracker(
     private[atlas] val atlasClient: AtlasClient,
@@ -61,7 +62,8 @@ class SparkExecutionPlanTracker(
 
   override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
     if (!qeQueue.offer(
-      QueryDetail(qe, executionId.getAndIncrement(), durationNs), timeout, TimeUnit.MILLISECONDS)) {
+      QueryDetail(qe, executionId.getAndIncrement(), durationNs, Option(SQLQuery.get())),
+        timeout, TimeUnit.MILLISECONDS)) {
       logError(s"Fail to put ${qe.toString()} into queue within time limit $timeout, will throw it")
     }
   }


### PR DESCRIPTION
Changes:
`SparkExecutionPlanTracker` and `CommandsHarvester` are in different threads, so we need to save users' SQL queries into `QueryDetail` included in query events, then `CommandsHarvester` can get the sql queries from query events.

Testing:
Manually tested in HDP cluster. Without this PR, the sql queries can not show in Atlas UI. With this PR, the sql queries can not show in Atlas UI:
<img width="591" alt="screen shot 2018-03-08 at 1 16 50 pm" src="https://user-images.githubusercontent.com/8546874/37177025-0044b3fa-22d3-11e8-9c24-c85298d04725.png">



This closes #38  .