### PR TITLE
[SAC-45] Record the Spark ML model and pipeline directory in the …

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/ml/MLPipelineEventProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/ml/MLPipelineEventProcessor.scala
@@ -129,7 +129,8 @@ class MLPipelineEventProcessor(
             (s"Spark ML training model with pipeline uid: ${pipeline.uid}"))
 
           val processEntity = internal.etlProcessToEntity(
-            List(pipelineEntity, tableEntities.head.head), List(modelEntity), logMap)
+            List(pipelineEntity, tableEntities.head.head),
+            List(modelEntity, modelDirEntity, pipelineDirEntity), logMap)
 
           atlasClient.createEntities(Seq(pipelineDirEntity, pipelineEntity, processEntity)
             ++ Seq(modelDirEntity, modelEntity) ++ tableEntities.head)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR record the directory information for Spark ML model and pipeline. 

## How was this patch tested?

Pass Travis CI, and the Atlas lineage is shown as below:

![screen shot 2018-05-30 at 3 14 16 pm](https://user-images.githubusercontent.com/1431801/40812142-1c2d6974-64e9-11e8-9971-810861376a3e.png)
![screen shot 2018-05-31 at 3 40 43 pm](https://user-images.githubusercontent.com/1431801/40812144-1c437246-64e9-11e8-8e13-dd1e35b65114.png)
