### PR TITLE
[SAC-55] Update the Spark Process Atlas record name

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -229,7 +229,10 @@ object internal extends Logging {
     val entity = new AtlasEntity(metadata.PROCESS_TYPE_STRING)
 
     val appId = SparkUtils.sparkSession.sparkContext.applicationId
-    val appName = SparkUtils.sparkSession.sparkContext.appName
+    val appName = SparkUtils.sparkSession.sparkContext.appName match {
+      case "Spark shell" => s"Spark Job + $appId"
+      case default => default + s" $appId"
+    }
     entity.setAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, appId)
     entity.setAttribute("name", appName)
     entity.setAttribute("currUser", SparkUtils.currUser())


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR update the name of Atlas record for Spark Process with Application ID. 

## How was this patch tested?

Attached the output figure later. 