### PR TITLE
[SAC-57] Reducing overhead to update entity for Spark Streaming query processing #57

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/SparkAtlasStreamingQueryEventTracker.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/SparkAtlasStreamingQueryEventTracker.scala
@@ -50,6 +50,7 @@ class SparkAtlasStreamingQueryEventTracker(
     logInfo(s"Track running Spark Streaming query in the Spark Atlas: $event")
     if(!streamQueryHashset.contains(event.progress.runId)) {
       streamingQueryTracker.pushEvent(event)
+      streamQueryHashset.add(event.progress.runId)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
For a Spark Streaming query, we track the related event but we do not need to update the process entity for each patch. 

## How was this patch tested?

Manually test 