### PR TITLE
[SAC-59] Spark streaming query sink to console is not atlas entity #59

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkStreamingQueryEventProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkStreamingQueryEventProcessor.scala
@@ -47,6 +47,9 @@ extends AbstractEventProcessor[QueryProgressEvent] with AtlasEntityUtils with Lo
       val path = e.progress.sink.description.substring(begin + 1, end)
       logDebug(s"record the streaming query sink output path information $path")
       outputEntity = external.pathToEntity(path)
+    } else if (e.progress.sink.description.contains("ConsoleSinkProvider")) {
+      logInfo(s"do not track the console output as Atlas entity ${e.progress.sink.description}")
+      return
     }
 
     val pName = e.progress.name match {


### PR DESCRIPTION
## What changes were proposed in this pull request?
When Spark streaming querying sink the data into console, the console output is not a Atlas entity. Thus, we do not track this. 

## How was this patch tested?
Manually test 