### PR TITLE
[SAC-61] Update the Spark ML model and pipeline related directory entity #61

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/ml/MLPipelineEventProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/ml/MLPipelineEventProcessor.scala
@@ -35,9 +35,7 @@ class MLPipelineEventProcessor(
   private[atlas] val atlasClient: AtlasClient,
     val conf: AtlasClientConf)
   extends AbstractEventProcessor[SparkListenerEvent] with AtlasEntityUtils with Logging {
-
-  private val uri = "hdfs://"
-
+  
   override def process(e: SparkListenerEvent): Unit = {
     e.getClass.getName match {
       case name if name.contains("CreatePipelineEvent") =>

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/ml/MLPipelineEventProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/ml/MLPipelineEventProcessor.scala
@@ -67,7 +67,7 @@ class MLPipelineEventProcessor(
         pathF.setAccessible(true)
         val path = pathF.get(e).asInstanceOf[String]
 
-        val pipelineDirEntity = internal.mlDirectoryToEntity(uri, path)
+        val pipelineDirEntity = external.pathToEntity(path)
         val pipeline = internal.cachedObjects(uid).asInstanceOf[Pipeline]
 
         val pipelineEntity = internal.mlPipelineToEntity(pipeline, pipelineDirEntity)
@@ -91,7 +91,7 @@ class MLPipelineEventProcessor(
         if (! internal.cachedObjects.contains(s"${uid}_pipelineDirEntity")) {
           logInfo(s"Model Entity is already created")
         } else {
-          val modelDirEntity = internal.mlDirectoryToEntity(uri, path)
+          val modelDirEntity = external.pathToEntity(path)
 
           val pipelineDirEntity = internal.cachedObjects(s"${uid}_pipelineDirEntity")
             .asInstanceOf[AtlasEntity]
@@ -148,7 +148,7 @@ class MLPipelineEventProcessor(
         directoryF.setAccessible(true)
         val directory = directoryF.get(e).asInstanceOf[String]
 
-        val modelDirEntity = internal.mlDirectoryToEntity(uri, directory)
+        val modelDirEntity = external.pathToEntity(directory)
         val modelEntity = internal.mlModelToEntity(model, modelDirEntity)
         val uid = model.uid
         internal.cachedObjects.put(s"${uid}_modelDirEntity", modelDirEntity)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Spark ML job need to store the pipeline and model into HDFS, we update the related directory into the same file entity as SQL processing related entity. 

## How was this patch tested?

Manually test 