### PR TITLE
[SAC-68] Fix the issue of Owner details are missing in DB entity

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/AtlasEntityUtils.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/AtlasEntityUtils.scala
@@ -41,9 +41,9 @@ trait AtlasEntityUtils {
 
   def dbToEntities(dbDefinition: CatalogDatabase): Seq[AtlasEntity] = {
     if (SparkUtils.isHiveEnabled()) {
-      external.hiveDbToEntities(dbDefinition, clusterName)
+      external.hiveDbToEntities(dbDefinition, clusterName, SparkUtils.currUser())
     } else {
-      internal.sparkDbToEntities(dbDefinition)
+      internal.sparkDbToEntities(dbDefinition, SparkUtils.currUser())
     }
   }
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -119,7 +119,9 @@ object external {
 
   def hiveDbUniqueAttribute(cluster: String, db: String): String = s"${db.toLowerCase}@$cluster"
 
-  def hiveDbToEntities(dbDefinition: CatalogDatabase, cluster: String): Seq[AtlasEntity] = {
+  def hiveDbToEntities(dbDefinition: CatalogDatabase,
+                       cluster: String,
+                       owner: String): Seq[AtlasEntity] = {
     val dbEntity = new AtlasEntity(HIVE_DB_TYPE_STRING)
 
     dbEntity.setAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME,
@@ -129,6 +131,7 @@ object external {
     dbEntity.setAttribute("description", dbDefinition.description)
     dbEntity.setAttribute("location", dbDefinition.locationUri.toString)
     dbEntity.setAttribute("parameters", dbDefinition.properties.asJava)
+    dbEntity.setAttribute("owner", owner)
     Seq(dbEntity)
   }
 
@@ -213,7 +216,7 @@ object external {
     val table = tableDefinition.identifier.table
     val dbDefinition = mockDbDefinition.getOrElse(SparkUtils.getExternalCatalog().getDatabase(db))
 
-    val dbEntities = hiveDbToEntities(dbDefinition, cluster)
+    val dbEntities = hiveDbToEntities(dbDefinition, cluster, tableDefinition.owner)
     val sdEntities = hiveStorageDescToEntities(
       tableDefinition.storage, cluster, db, table
       /* isTempTable = false  Spark doesn't support temp table */)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -36,7 +36,7 @@ object internal extends Logging {
 
   def sparkDbUniqueAttribute(db: String): String = SparkUtils.getUniqueQualifiedPrefix() + db
 
-  def sparkDbToEntities(dbDefinition: CatalogDatabase): Seq[AtlasEntity] = {
+  def sparkDbToEntities(dbDefinition: CatalogDatabase, owner: String): Seq[AtlasEntity] = {
     val dbEntity = new AtlasEntity(metadata.DB_TYPE_STRING)
     val pathEntity = external.pathToEntity(dbDefinition.locationUri.toString)
 
@@ -46,6 +46,7 @@ object internal extends Logging {
     dbEntity.setAttribute("description", dbDefinition.description)
     dbEntity.setAttribute("locationUri", pathEntity)
     dbEntity.setAttribute("properties", dbDefinition.properties.asJava)
+    dbEntity.setAttribute("owner", owner)
     Seq(dbEntity, pathEntity)
   }
 
@@ -103,7 +104,7 @@ object internal extends Logging {
     val dbDefinition = mockDbDefinition
       .getOrElse(SparkUtils.getExternalCatalog().getDatabase(db))
 
-    val dbEntities = sparkDbToEntities(dbDefinition)
+    val dbEntities = sparkDbToEntities(dbDefinition, tableDefinition.owner)
     val sdEntities =
       sparkStorageFormatToEntities(tableDefinition.storage, db, tableDefinition.identifier.table)
     val schemaEntities =

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CatalogEventToAtlasIT.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CatalogEventToAtlasIT.scala
@@ -67,6 +67,7 @@ class CatalogEventToAtlasIT extends BaseResourceIT with Matchers {
       val entity = getEntity(processor.dbType, processor.dbUniqueAttribute("db1"))
       entity should not be (null)
       entity.getAttribute("name") should be ("db1")
+      entity.getAttribute("owner") should be (SparkUtils.currUser())
     }
 
     // Drop DB from external catalog to make sure we also delete the corresponding Atlas entity


### PR DESCRIPTION
## What is proposed in this PR? 
Record the create information for the Hive and Spark DB entity. 

## How this patch is tested? 
Local test and test on a real cluster. 