### PR TITLE
Exclude Guava from the Atlas Client V2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,12 @@
       <groupId>org.apache.atlas</groupId>
       <artifactId>atlas-client-v2</artifactId>
       <version>${atlas.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### What is proposed in the PR
Exclude Guava from Uber jar, since Altas 1.0 are using Guava 19.0

### How the patch is tested 
Local test