### PR TITLE
Update to V2 client and rename schema to spark_schema

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessor.scala
@@ -144,7 +144,7 @@ class SparkCatalogEventProcessor(
             atlasClient.createEntities(schemaEntities)
 
             val tableEntity = new AtlasEntity(tableType(isHiveTbl))
-            tableEntity.setAttribute("schema", schemaEntities.asJava)
+            tableEntity.setAttribute("spark_schema", schemaEntities.asJava)
             atlasClient.updateEntityWithUniqueAttr(
               tableType(isHiveTbl),
               tableUniqueAttribute(db, table, isHiveTbl),

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -23,7 +23,7 @@ import java.util.Date
 
 import scala.collection.JavaConverters._
 
-import org.apache.atlas.{AtlasClient, AtlasConstants}
+import org.apache.atlas.AtlasConstants
 import org.apache.atlas.hbase.bridge.HBaseAtlasHook._
 import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.commons.lang.RandomStringUtils
@@ -50,10 +50,10 @@ object external {
     }
 
     val fsPath = new Path(uri)
-    entity.setAttribute(AtlasClient.NAME,
+    entity.setAttribute("name",
       Path.getPathWithoutSchemeAndAuthority(fsPath).toString.toLowerCase)
     entity.setAttribute("path", Path.getPathWithoutSchemeAndAuthority(fsPath).toString.toLowerCase)
-    entity.setAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, uri.toString)
+    entity.setAttribute("qualifiedName", uri.toString)
     if (uri.getScheme == "hdfs") {
       entity.setAttribute(AtlasConstants.CLUSTER_NAME_ATTRIBUTE, uri.getAuthority)
     }
@@ -89,9 +89,9 @@ object external {
   def hbaseTableToEntity(cluster: String, tableName: String, nameSpace: String)
       : Seq[AtlasEntity] = {
     val hbaseEntity = new AtlasEntity(HBASE_TABLE_STRING)
-    hbaseEntity.setAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME,
+    hbaseEntity.setAttribute("qualifiedName",
       getTableQualifiedName(cluster, nameSpace, tableName))
-    hbaseEntity.setAttribute(AtlasClient.NAME, tableName.toLowerCase)
+    hbaseEntity.setAttribute("name", tableName.toLowerCase)
     hbaseEntity.setAttribute(AtlasConstants.CLUSTER_NAME_ATTRIBUTE, cluster)
     hbaseEntity.setAttribute("uri", nameSpace.toLowerCase + ":" + tableName.toLowerCase)
     Seq(hbaseEntity)
@@ -102,9 +102,9 @@ object external {
 
   def kafkaToEntity(cluster: String, topicName: String): Seq[AtlasEntity] = {
     val kafkaEntity = new AtlasEntity(KAFKA_TOPIC_STRING)
-    kafkaEntity.setAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME,
+    kafkaEntity.setAttribute("qualifiedName",
       topicName.toLowerCase + '@' + cluster)
-    kafkaEntity.setAttribute(AtlasClient.NAME, topicName.toLowerCase)
+    kafkaEntity.setAttribute("name", topicName.toLowerCase)
     kafkaEntity.setAttribute(AtlasConstants.CLUSTER_NAME_ATTRIBUTE, cluster)
     kafkaEntity.setAttribute("uri", topicName.toLowerCase)
     kafkaEntity.setAttribute("topic", topicName.toLowerCase)
@@ -124,9 +124,9 @@ object external {
                        owner: String): Seq[AtlasEntity] = {
     val dbEntity = new AtlasEntity(HIVE_DB_TYPE_STRING)
 
-    dbEntity.setAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME,
+    dbEntity.setAttribute("qualifiedName",
       hiveDbUniqueAttribute(cluster, dbDefinition.name.toLowerCase))
-    dbEntity.setAttribute(AtlasClient.NAME, dbDefinition.name.toLowerCase)
+    dbEntity.setAttribute("name", dbDefinition.name.toLowerCase)
     dbEntity.setAttribute(AtlasConstants.CLUSTER_NAME_ATTRIBUTE, cluster)
     dbEntity.setAttribute("description", dbDefinition.description)
     dbEntity.setAttribute("location", dbDefinition.locationUri.toString)
@@ -150,13 +150,13 @@ object external {
       table: String,
       isTempTable: Boolean = false): Seq[AtlasEntity] = {
     val sdEntity = new AtlasEntity(HIVE_STORAGEDESC_TYPE_STRING)
-    sdEntity.setAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME,
+    sdEntity.setAttribute("qualifiedName",
       hiveStorageDescUniqueAttribute(cluster, db, table, isTempTable))
     storageFormat.inputFormat.foreach(sdEntity.setAttribute("inputFormat", _))
     storageFormat.outputFormat.foreach(sdEntity.setAttribute("outputFormat", _))
     sdEntity.setAttribute("compressed", storageFormat.compressed)
     sdEntity.setAttribute("parameters", storageFormat.properties.asJava)
-    storageFormat.serde.foreach(sdEntity.setAttribute(AtlasClient.NAME, _))
+    storageFormat.serde.foreach(sdEntity.setAttribute("name", _))
     storageFormat.locationUri.foreach { u => sdEntity.setAttribute("location", u.toString) }
     Seq(sdEntity)
   }
@@ -181,9 +181,9 @@ object external {
     schema.map { struct =>
       val entity = new AtlasEntity(HIVE_COLUMN_TYPE_STRING)
 
-      entity.setAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME,
+      entity.setAttribute("qualifiedName",
         hiveColumnUniqueAttribute(cluster, db, table, struct.name, isTempTable))
-      entity.setAttribute(AtlasClient.NAME, struct.name)
+      entity.setAttribute("name", struct.name)
       entity.setAttribute("type", struct.dataType.typeName)
       entity.setAttribute("comment", struct.getComment())
       entity
@@ -224,10 +224,10 @@ object external {
       tableDefinition.schema, cluster, db, table /* , isTempTable = false */)
 
     val tblEntity = new AtlasEntity(HIVE_TABLE_TYPE_STRING)
-    tblEntity.setAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME,
+    tblEntity.setAttribute("qualifiedName",
       hiveTableUniqueAttribute(cluster, db, table /* , isTemporary = false */))
-    tblEntity.setAttribute(AtlasClient.NAME, table)
-    tblEntity.setAttribute(AtlasClient.OWNER, tableDefinition.owner)
+    tblEntity.setAttribute("name", table)
+    tblEntity.setAttribute("owner", tableDefinition.owner)
     tblEntity.setAttribute("createTime", new Date(tableDefinition.createTime))
     tblEntity.setAttribute("lastAccessTime", new Date(tableDefinition.lastAccessTime))
     tableDefinition.comment.foreach(tblEntity.setAttribute("comment", _))

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
@@ -18,7 +18,6 @@
 package com.hortonworks.spark.atlas.types
 
 import com.google.common.collect.{ImmutableMap, ImmutableSet}
-import org.apache.atlas.AtlasClient
 import org.apache.atlas.`type`.AtlasBuiltInTypes.{AtlasBooleanType, AtlasLongType, AtlasStringType}
 import org.apache.atlas.`type`.{AtlasArrayType, AtlasMapType, AtlasTypeUtil}
 import org.apache.atlas.model.typedef.AtlasStructDef.AtlasConstraintDef
@@ -46,7 +45,7 @@ object metadata {
     METADATA_VERSION,
     ImmutableSet.of("DataSet"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
-      AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, new AtlasStringType),
+      "qualifiedName", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("description", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("locationUri", FS_PATH_TYPE_STRING),
     AtlasTypeUtil.createOptionalAttrDef(
@@ -59,7 +58,7 @@ object metadata {
     METADATA_VERSION,
     ImmutableSet.of("Referenceable"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
-      AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, new AtlasStringType),
+      "qualifiedName", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("locationUri", FS_PATH_TYPE_STRING),
     AtlasTypeUtil.createOptionalAttrDef("inputFormat", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("outputFormat", new AtlasStringType),
@@ -80,7 +79,7 @@ object metadata {
     METADATA_VERSION,
     ImmutableSet.of("DataSet"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
-      AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, new AtlasStringType),
+      "qualifiedName", new AtlasStringType),
     AtlasTypeUtil.createRequiredAttrDef("type", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("nullable", new AtlasBooleanType),
     AtlasTypeUtil.createOptionalAttrDef("metadata", new AtlasStringType),
@@ -88,7 +87,7 @@ object metadata {
       "table",
       TABLE_TYPE_STRING,
       AtlasConstraintDef.CONSTRAINT_TYPE_INVERSE_REF,
-      ImmutableMap.of(AtlasConstraintDef.CONSTRAINT_PARAM_ATTRIBUTE, "schema")))
+      ImmutableMap.of(AtlasConstraintDef.CONSTRAINT_PARAM_ATTRIBUTE, "spark_schema")))
 
   // ========= Table type =========
   val TABLE_TYPE = AtlasTypeUtil.createClassTypeDef(
@@ -97,13 +96,13 @@ object metadata {
     METADATA_VERSION,
     ImmutableSet.of("DataSet"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
-      AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, new AtlasStringType),
+      "qualifiedName", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("database", DB_TYPE_STRING),
     AtlasTypeUtil.createOptionalAttrDef("tableType", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDefWithConstraint(
       "storage", STORAGEDESC_TYPE_STRING, AtlasConstraintDef.CONSTRAINT_TYPE_OWNED_REF, null),
     AtlasTypeUtil.createOptionalAttrDefWithConstraint(
-      "schema",
+      "spark_schema",
       "array<spark_column>",
       AtlasConstraintDef.CONSTRAINT_TYPE_OWNED_REF, null),
     AtlasTypeUtil.createOptionalAttrDef("provider", new AtlasStringType),
@@ -127,7 +126,7 @@ object metadata {
     METADATA_VERSION,
     ImmutableSet.of("Process"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
-      AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, new AtlasStringType),
+      "qualifiedName", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("executionId", new AtlasLongType),
     AtlasTypeUtil.createOptionalAttrDef("currUser", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("remoteUser", new AtlasStringType),
@@ -142,7 +141,7 @@ object metadata {
     METADATA_VERSION,
     ImmutableSet.of("DataSet"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
-      AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, new AtlasStringType),
+      "qualifiedName", new AtlasStringType),
     AtlasTypeUtil.createRequiredAttrDef("uri", new AtlasStringType),
     AtlasTypeUtil.createRequiredAttrDef("directory", new AtlasStringType))
 
@@ -153,7 +152,7 @@ object metadata {
     METADATA_VERSION,
     ImmutableSet.of("DataSet"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
-      AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, new AtlasStringType),
+      "qualifiedName", new AtlasStringType),
     AtlasTypeUtil.createRequiredAttrDef("directory", ML_DIRECTORY_TYPE_STRING),
     AtlasTypeUtil.createOptionalAttrDef("description", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("extra", new AtlasStringType))
@@ -165,7 +164,7 @@ object metadata {
     METADATA_VERSION,
     ImmutableSet.of("DataSet"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
-      AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, new AtlasStringType),
+      "qualifiedName", new AtlasStringType),
     AtlasTypeUtil.createRequiredAttrDef("directory", ML_DIRECTORY_TYPE_STRING),
     AtlasTypeUtil.createOptionalAttrDef("description", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("extra", new AtlasStringType))
@@ -177,7 +176,7 @@ object metadata {
     METADATA_VERSION,
     ImmutableSet.of("Process"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
-      AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, new AtlasStringType),
+      "qualifiedName", new AtlasStringType),
     AtlasTypeUtil.createRequiredAttrDef("pipeline", ML_PIPELINE_TYPE_STRING),
 //    AtlasTypeUtil.createOptionalAttrDef("startTime", new AtlasLongType),
 //    AtlasTypeUtil.createOptionalAttrDef("endTime", new AtlasLongType),
@@ -191,7 +190,7 @@ object metadata {
     METADATA_VERSION,
     ImmutableSet.of("Process"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
-      AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, new AtlasStringType),
+      "qualifiedName", new AtlasStringType),
     AtlasTypeUtil.createRequiredAttrDef("model", ML_MODEL_TYPE_STRING),
 //    AtlasTypeUtil.createOptionalAttrDef("startTime", new AtlasLongType),
 //    AtlasTypeUtil.createOptionalAttrDef("endTime", new AtlasLongType),
@@ -205,7 +204,7 @@ object metadata {
     METADATA_VERSION,
     ImmutableSet.of("Process"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
-      AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, new AtlasStringType),
+      "qualifiedName", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("executionId", new AtlasLongType),
     AtlasTypeUtil.createOptionalAttrDef("currUser", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("remoteUser", new AtlasStringType),

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/SparkAtlasEntityUtilsSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/SparkAtlasEntityUtilsSuite.scala
@@ -125,7 +125,7 @@ class SparkAtlasEntityUtilsSuite extends FunSuite with Matchers with BeforeAndAf
     tableEntity.getAttribute("name") should be ("tbl1")
     tableEntity.getAttribute("database") should be (dbEntity)
     tableEntity.getAttribute("storage") should be (sdEntity)
-    tableEntity.getAttribute("schema") should be (schemaEntities.asJava)
+    tableEntity.getAttribute("spark_schema") should be (schemaEntities.asJava)
   }
 }
 


### PR DESCRIPTION
- Switch to V2 connections
- Use spark_schema to avoid naming collision fixes #70 

