### PR TITLE
Update ML event tracker to match the update on the Spark ML side

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -172,19 +172,19 @@ object internal extends Logging {
     entity
   }
 
-  def mlPipelineToEntity(pipeline: Pipeline, directory: AtlasEntity): AtlasEntity = {
+  def mlPipelineToEntity(pipeline_uid: String, directory: AtlasEntity): AtlasEntity = {
     val entity = new AtlasEntity(metadata.ML_PIPELINE_TYPE_STRING)
 
-    entity.setAttribute("qualifiedName", pipeline.uid)
-    entity.setAttribute("name", pipeline.uid)
+    entity.setAttribute("qualifiedName", pipeline_uid)
+    entity.setAttribute("name", pipeline_uid)
     entity.setAttribute("directory", directory)
     entity
   }
 
-  def mlModelToEntity(model: PipelineModel, directory: AtlasEntity): AtlasEntity = {
+  def mlModelToEntity(model_uid: String, directory: AtlasEntity): AtlasEntity = {
     val entity = new AtlasEntity(metadata.ML_MODEL_TYPE_STRING)
 
-    val uid = model.uid.replaceAll("pipeline", "model")
+    val uid = model_uid.replaceAll("pipeline", "model")
     entity.setAttribute("qualifiedName", uid)
     entity.setAttribute("name", uid)
     entity.setAttribute("directory", directory)

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/ml/MLPipelineTrackerIT.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/ml/MLPipelineTrackerIT.scala
@@ -93,11 +93,11 @@ class MLPipelineTrackerIT extends BaseResourceIT with Matchers with BeforeAndAft
 
     pipeline.write.overwrite().save(pipelineDir)
 
-    val pipelineEntity = internal.mlPipelineToEntity(pipeline, pipelineDirEntity)
+    val pipelineEntity = internal.mlPipelineToEntity(pipeline.uid, pipelineDirEntity)
 
     atlasClient.createEntities(Seq(pipelineDirEntity, pipelineEntity))
 
-    val modelEntity = internal.mlModelToEntity(model, modelDirEntity)
+    val modelEntity = internal.mlModelToEntity(model.uid, modelDirEntity)
 
     atlasClient.createEntities(Seq(modelDirEntity, modelEntity))
 

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/ml/MLPipelineWithSaveIntoSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/ml/MLPipelineWithSaveIntoSuite.scala
@@ -125,8 +125,8 @@ class MLPipelineWithSaveIntoSuite extends BaseResourceIT with Matchers with Befo
     val model = pipeline.fit(trainData)
     pipeline.write.overwrite().save(pipelineDir)
 
-    val pipelineEntity = internal.mlPipelineToEntity(pipeline, pipelineDirEntity)
-    val modelEntity = internal.mlModelToEntity(model, modelDirEntity)
+    val pipelineEntity = internal.mlPipelineToEntity(pipeline.uid, pipelineDirEntity)
+    val modelEntity = internal.mlModelToEntity(model.uid, modelDirEntity)
 
     val logMap = Map("sparkPlanDescription" ->
       (s"Spark ML training model with pipeline uid: ${pipeline.uid}"))
@@ -172,8 +172,8 @@ class MLPipelineWithSaveIntoSuite extends BaseResourceIT with Matchers with Befo
     val model = pipeline.fit(trainData)
     pipeline.write.overwrite().save(pipelineDir)
 
-    val pipelineEntity = internal.mlPipelineToEntity(pipeline, pipelineDirEntity)
-    val modelEntity = internal.mlModelToEntity(model, modelDirEntity)
+    val pipelineEntity = internal.mlPipelineToEntity(pipeline.uid, pipelineDirEntity)
+    val modelEntity = internal.mlModelToEntity(model.uid, modelDirEntity)
 
     val logMap = Map("sparkPlanDescription" ->
       (s"Spark ML training model with pipeline uid: ${pipeline.uid}"))

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/MLAtlasEntityUtilsSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/MLAtlasEntityUtilsSuite.scala
@@ -93,13 +93,13 @@ class MLAtlasEntityUtilsSuite extends FunSuite with Matchers with BeforeAndAfter
 
     pipeline.write.overwrite().save(pipelineDir)
 
-    val pipelineEntity = internal.mlPipelineToEntity(pipeline, pipelineDirEntity)
+    val pipelineEntity = internal.mlPipelineToEntity(pipeline.uid, pipelineDirEntity)
     pipelineEntity.getTypeName should be (metadata.ML_PIPELINE_TYPE_STRING)
     pipelineEntity.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (pipeline.uid)
     pipelineEntity.getAttribute("name") should be (pipeline.uid)
     pipelineEntity.getAttribute("directory") should be (pipelineDirEntity)
 
-    val modelEntity = internal.mlModelToEntity(model, modelDirEntity)
+    val modelEntity = internal.mlModelToEntity(model.uid, modelDirEntity)
     val modelUid = model.uid.replaceAll("pipeline", "model")
     modelEntity.getTypeName should be (metadata.ML_MODEL_TYPE_STRING)
     modelEntity.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (modelUid)


### PR DESCRIPTION
### what is proposed in this PR 

We remove the unnecessary Spark ML event related information like Spark ML model and Spark ML pipeline. Thus, we need to update the SAC side. 

### how to test this PR

Local test 