### PR TITLE
[SAC-79] Leverage KafkaStreamWriterFactory to avoid reflection while getting destination topic (Spark 2.3.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <atlas.version>1.1.0</atlas.version>
     <scala.version>2.11.8</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
+    <kafka.version>0.10.0.1</kafka.version>
     <MaxPermGen>512m</MaxPermGen>
     <CodeCacheSize>512m</CodeCacheSize>
     <minJavaVersion>1.8</minJavaVersion>
@@ -142,6 +143,21 @@
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql-kafka-0-10_${scala.binary.version}</artifactId>
+      <version>${spark.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka_${scala.binary.version}</artifactId>
+      <version>${kafka.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.execution.datasources.{InsertIntoHadoopFsRelationCom
 import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec
 import org.apache.spark.sql.execution.streaming.sources.InternalRowMicroBatchWriter
 import org.apache.spark.sql.hive.execution._
-import org.apache.spark.sql.kafka010.KafkaStreamWriter
 import org.apache.spark.sql.kafka010.atlas.KafkaHarvester
 import com.hortonworks.spark.atlas.{AbstractEventProcessor, AtlasClient, AtlasClientConf}
 import com.hortonworks.spark.atlas.utils.Logging

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.execution.streaming.sources.InternalRowMicroBatchWri
 import org.apache.spark.sql.hive.execution._
 import org.apache.spark.sql.kafka010.KafkaStreamWriter
 import org.apache.spark.sql.kafka010.atlas.KafkaHarvester
-
 import com.hortonworks.spark.atlas.{AbstractEventProcessor, AtlasClient, AtlasClientConf}
 import com.hortonworks.spark.atlas.utils.Logging
 
@@ -91,17 +90,13 @@ class SparkExecutionPlanProcessor(
       case r: WriteToDataSourceV2Exec =>
         r.writer match {
           case w: InternalRowMicroBatchWriter =>
-            try {
-              val streamWriter = w.getClass.getMethod("writer").invoke(w)
-              streamWriter match {
-                case sw: KafkaStreamWriter => KafkaHarvester.harvest(sw, r, qd)
-                case _ => Seq.empty
-              }
-            } catch {
-              case _: NoSuchMethodException =>
-                logDebug("Can not get KafkaStreamWriter, so can not create Kafka topic " +
-                  s"entities: ${qd.qe}")
-                Seq.empty
+            // Unfortunately, we cannot determine whether writer is kafka or not, before calling
+            // `createInternalRowWriterFactory()`. We have no option, have to take the risk.
+            val (isKafkaWriter, topic) = KafkaHarvester.extractTopic(w)
+            if (isKafkaWriter) {
+              KafkaHarvester.harvest(topic, r, qd)
+            } else {
+              Seq.empty
             }
 
           case _ =>

--- a/spark-atlas-connector/src/main/scala/org/apache/spark/sql/kafka010/atlas/KafkaHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/org/apache/spark/sql/kafka010/atlas/KafkaHarvester.scala
@@ -20,46 +20,48 @@ package org.apache.spark.sql.kafka010.atlas
 import scala.collection.mutable.ListBuffer
 import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.spark.sql.execution.RDDScanExec
-import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec
-import org.apache.spark.sql.kafka010.{KafkaSourceRDDPartition, KafkaStreamWriter}
+import org.apache.spark.sql.execution.datasources.v2.{DataSourceRDDPartition, DataSourceV2ScanExec, WriteToDataSourceV2Exec}
+import org.apache.spark.sql.kafka010._
 import com.hortonworks.spark.atlas.AtlasClientConf
 import com.hortonworks.spark.atlas.sql.QueryDetail
 import com.hortonworks.spark.atlas.types.{AtlasEntityUtils, external, internal}
 import com.hortonworks.spark.atlas.utils.{Logging, SparkUtils}
+import org.apache.spark.sql.execution.streaming.sources.InternalRowMicroBatchWriter
+
+import scala.collection.mutable
 
 object KafkaHarvester extends AtlasEntityUtils with Logging {
   override val conf: AtlasClientConf = new AtlasClientConf
 
-  def harvest(node: KafkaStreamWriter, writer: WriteToDataSourceV2Exec,
-    qd: QueryDetail) : Seq[AtlasEntity] = {
+  def extractTopic(writer: InternalRowMicroBatchWriter): (Boolean, Option[String]) = {
+    // Unfortunately neither KafkaStreamWriter is a case class nor topic is a field.
+    // Hopefully KafkaStreamWriterFactory is a case class instead, so we can extract
+    // topic information from there.
+    // The cost of createInternalRowWriterFactory is tiny (case class object creation)
+    // for this case, and we can find the way to cache it once we find the cost is not ignorable.
+    writer.createInternalRowWriterFactory() match {
+      case KafkaStreamWriterFactory(tp, _, _) => (true, tp)
+      case _ => (false, None)
+    }
+  }
+
+  def harvest(targetTopic: Option[String], writer: WriteToDataSourceV2Exec,
+              qd: QueryDetail) : Seq[AtlasEntity] = {
     // source topics - can be multiple topics
     val read_from_topics = new ListBuffer[String]()
     val tChildren = writer.query.collectLeaves()
-    val inputsEntities = tChildren.flatMap{
-      case r: RDDScanExec =>
-        r.rdd.partitions.map {
-          case e: KafkaSourceRDDPartition =>
-            val topic = e.offsetRange.topic
-            read_from_topics += topic
-            external.kafkaToEntity(clusterName, topic)
-        }.toSeq.flatten
+    val topics: Set[String] = tChildren.flatMap {
+      case r: RDDScanExec => extractSourceTopicsFromDataSourceV1(r)
+      case r: DataSourceV2ScanExec => extractSourceTopicsFromDataSourceV2(r)
+      case _ => Nil
+    }.toSet
+
+    val inputsEntities: Seq[AtlasEntity] = topics.toList.flatMap { topic =>
+      external.kafkaToEntity(clusterName, topic)
     }
 
-    // destination topic
-    var destTopic = None: Option[String]
-    try {
-      val topicField = node.getClass.getDeclaredField("topic")
-      topicField.setAccessible(true)
-      destTopic = topicField.get(node).asInstanceOf[Option[String]]
-    } catch {
-      case e: NoSuchMethodException =>
-        logDebug(s"Can not get topic, so can not create Kafka topic entities: ${qd.qe}")
-      case e: Exception =>
-        logDebug(s"Can not get topic, please update topic of KafkaStreamWriter: ${e.toString}")
-    }
-
-    val outputEntities = if (destTopic.isDefined) {
-      external.kafkaToEntity(clusterName, destTopic.get)
+    val outputEntities = if (targetTopic.isDefined) {
+      external.kafkaToEntity(clusterName, targetTopic.get)
     } else {
       Seq.empty
     }
@@ -70,8 +72,8 @@ object KafkaHarvester extends AtlasEntityUtils with Logging {
       e => pDescription.append(e).append(" ")
     }
 
-    if(destTopic.isDefined) {
-      pDescription.append(") Topics written into( ").append(destTopic.get).append(" )")
+    if (targetTopic.isDefined) {
+      pDescription.append(") Topics written into( ").append(targetTopic.get).append(" )")
     } else {
       logInfo(s"Can not get dest topic")
     }
@@ -98,8 +100,34 @@ object KafkaHarvester extends AtlasEntityUtils with Logging {
         inputTablesEntities, outputTableEntities, logMap)
 
       Seq(pEntity) ++ inputsEntities ++ outputEntities
-
     }
+  }
 
+  private def extractSourceTopicsFromDataSourceV1(r: RDDScanExec) = {
+    val topics = new mutable.HashSet[String]()
+    r.rdd.partitions.foreach {
+      case e: KafkaSourceRDDPartition =>
+        val topic = e.offsetRange.topic
+        topics += topic
+    }
+    topics
+  }
+
+  private def extractSourceTopicsFromDataSourceV2(r: DataSourceV2ScanExec) = {
+    val topics = new mutable.HashSet[String]()
+    r.inputRDDs().foreach(rdd => rdd.partitions.foreach {
+      case e: DataSourceRDDPartition[_] =>
+        e.readerFactory match {
+          case e1: KafkaContinuousDataReaderFactory =>
+            val topic = e1.topicPartition.topic()
+            topics += topic
+
+          case _ =>
+        }
+
+      case _ =>
+    })
+
+    topics
   }
 }

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql
+
+import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicLong
+
+import com.hortonworks.spark.atlas.types.external.KAFKA_TOPIC_STRING
+import com.hortonworks.spark.atlas.types.metadata
+import com.hortonworks.spark.atlas.utils.SparkUtils
+import com.hortonworks.spark.atlas.{AtlasClient, AtlasClientConf}
+import com.sun.jersey.core.util.MultivaluedMapImpl
+import org.apache.atlas.model.instance.AtlasEntity
+import org.apache.atlas.model.typedef.AtlasTypesDef
+import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.kafka010.KafkaTestUtils
+import org.apache.spark.sql.streaming.{StreamTest, StreamingQuery}
+import org.apache.spark.sql.util.QueryExecutionListener
+
+import scala.collection.convert.Wrappers.SeqWrapper
+import scala.collection.mutable
+
+class SparkExecutionPlanProcessorForStreamingQuerySuite extends StreamTest {
+  val brokerProps: Map[String, Object] = Map[String, Object]()
+  var testUtils: KafkaTestUtils = _
+
+  val atlasClientConf: AtlasClientConf = new AtlasClientConf()
+    .set(AtlasClientConf.CHECK_MODEL_IN_START.key, "false")
+  var atlasClient: CreateEntitiesTrackingAtlasClient = _
+  val testHelperQueryListener = new AtlasQueryExecutionListener()
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    testUtils = new KafkaTestUtils(brokerProps)
+    testUtils.setup()
+    atlasClient = new CreateEntitiesTrackingAtlasClient()
+    testHelperQueryListener.clear()
+    spark.listenerManager.register(testHelperQueryListener)
+  }
+
+  override def afterAll(): Unit = {
+    if (testUtils != null) {
+      testUtils.teardown()
+      testUtils = null
+    }
+    atlasClient = null
+    spark.listenerManager.unregister(testHelperQueryListener)
+    super.afterAll()
+  }
+
+  class DirectProcessSparkExecutionPlanProcessor(
+      atlasClient: AtlasClient,
+      atlasClientConf: AtlasClientConf)
+    extends SparkExecutionPlanProcessor(atlasClient, atlasClientConf) {
+
+    override def process(qd: QueryDetail): Unit = super.process(qd)
+  }
+
+  test("Kafka source(s) to kafka sink - micro-batch query") {
+    val planProcessor = new DirectProcessSparkExecutionPlanProcessor(atlasClient, atlasClientConf)
+
+    val topicsToRead = Seq("sparkread1", "sparkread2", "sparkread3")
+    val topicToWrite = "sparkwrite"
+    val topics = topicsToRead :+ topicToWrite
+
+    val brokerAddress = testUtils.brokerAddress
+
+    topics.foreach(testUtils.createTopic(_, 10, overwrite = true))
+
+    val tempDir = Files.createTempDirectory("spark-atlas-kafka-harvester")
+
+    val df = spark.readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", brokerAddress)
+      .option("subscribe", topicsToRead.mkString(","))
+      .option("startingOffsets", "earliest")
+      .load()
+
+    val query = df.writeStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", brokerAddress)
+      .option("topic", topicToWrite)
+      .option("checkpointLocation", tempDir.toAbsolutePath.toString)
+      .start()
+
+    // remove temporary directory in shutdown
+    org.apache.hadoop.util.ShutdownHookManager.get().addShutdownHook(
+      new Runnable {
+        override def run(): Unit = {
+          Files.deleteIfExists(tempDir)
+        }
+      }, 10)
+
+    try {
+      sendMessages(topicsToRead)
+      waitForBatchCompleted(query, testHelperQueryListener)
+
+      val queryDetail = testHelperQueryListener.queryDetails.head
+      planProcessor.process(queryDetail)
+      val entities = atlasClient.createdEntities
+
+      assertEntitiesKafkaTopicType(topics, entities)
+      assertEntitySparkProcessType(topicsToRead, topicToWrite, entities, queryDetail)
+    } finally {
+      query.stop()
+    }
+  }
+
+  private def sendMessages(topicsToRead: Seq[String]): Unit = {
+    topicsToRead.foreach { topic =>
+      testUtils.sendMessages(topic, Array("1", "2", "3", "4", "5"))
+    }
+  }
+
+  private def waitForBatchCompleted(query: StreamingQuery, listener: AtlasQueryExecutionListener)
+  : Unit = {
+    import org.scalatest.time.SpanSugar._
+    eventually(timeout(10.seconds)) {
+      query.processAllAvailable()
+      assert(listener.queryDetails.nonEmpty)
+    }
+  }
+
+  private def assertEntitiesKafkaTopicType(topics: Seq[String], entities: Seq[AtlasEntity])
+    : Unit = {
+    val kafkaTopicEntities = entities.filter(p => p.getTypeName.equals(KAFKA_TOPIC_STRING))
+
+    assert(kafkaTopicEntities.size === topics.size)
+    assert(kafkaTopicEntities.map(_.getAttribute("name").toString()).toSet === topics.toSet)
+    assert(kafkaTopicEntities.map(_.getAttribute("topic").toString()).toSet === topics.toSet)
+    assert(kafkaTopicEntities.map(_.getAttribute("uri").toString()).toSet === topics.toSet)
+  }
+
+  private def assertEntitySparkProcessType(topicsToRead: Seq[String], topicToWrite: String,
+                                           entities: Seq[AtlasEntity], queryDetail: QueryDetail)
+    : Unit = {
+    val processEntities = entities.filter { p =>
+      p.getTypeName.equals(metadata.PROCESS_TYPE_STRING)
+    }
+
+    assert(processEntities.size === 1)
+    val processEntity = processEntities.head
+
+    val inputs = processEntity.getAttribute("inputs")
+      .asInstanceOf[SeqWrapper[AtlasEntity]].underlying
+    val outputs = processEntity.getAttribute("outputs")
+      .asInstanceOf[SeqWrapper[AtlasEntity]].underlying
+
+    assert(!inputs.exists(_.getTypeName != KAFKA_TOPIC_STRING))
+    assert(!outputs.exists(_.getTypeName != KAFKA_TOPIC_STRING))
+
+    assert(inputs.map(_.getAttribute("name")).toSet === topicsToRead.toSet)
+    assert(outputs.map(_.getAttribute("name")).toSet === Seq(topicToWrite).toSet)
+
+    // verify others
+    val expectedMap = Map(
+      "executionId" -> queryDetail.executionId.toString,
+      "remoteUser" -> SparkUtils.currSessionUser(queryDetail.qe),
+      "executionTime" -> queryDetail.executionTime.toString,
+      "details" -> queryDetail.qe.toString()
+    )
+
+    expectedMap.foreach { case (key, value) =>
+      assert(processEntity.getAttribute(key) === value)
+    }
+  }
+
+  class AtlasQueryExecutionListener extends QueryExecutionListener {
+    private val executionId = new AtomicLong(0L)
+    val queryDetails = new mutable.MutableList[QueryDetail]()
+
+    override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
+      queryDetails += QueryDetail(qe, executionId.getAndIncrement(), durationNs)
+    }
+
+    override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {
+      fail(exception)
+    }
+
+    def clear(): Unit = {
+      queryDetails.clear()
+    }
+  }
+
+  class CreateEntitiesTrackingAtlasClient extends AtlasClient {
+    val createdEntities = new mutable.ListBuffer[AtlasEntity]()
+
+    override def createAtlasTypeDefs(typeDefs: AtlasTypesDef): Unit = {}
+
+    override def getAtlasTypeDefs(searchParams: MultivaluedMapImpl): AtlasTypesDef = {
+      new AtlasTypesDef()
+    }
+
+    override def updateAtlasTypeDefs(typeDefs: AtlasTypesDef): Unit = {}
+
+    override protected def doCreateEntities(entities: Seq[AtlasEntity]): Unit = {
+      createdEntities ++= entities
+    }
+
+    override protected def doDeleteEntityWithUniqueAttr(entityType: String,
+                                                        attribute: String): Unit = {}
+
+    override protected def doUpdateEntityWithUniqueAttr(entityType: String, attribute: String,
+                                                        entity: AtlasEntity): Unit = {}
+  }
+}

--- a/spark-atlas-connector/src/test/scala/org/apache/spark/sql/kafka010/atlas/KafkaHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/org/apache/spark/sql/kafka010/atlas/KafkaHarvesterSuite.scala
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kafka010.atlas
+
+import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicLong
+
+import com.hortonworks.spark.atlas.sql.QueryDetail
+import com.hortonworks.spark.atlas.types.external.KAFKA_TOPIC_STRING
+import com.hortonworks.spark.atlas.types.metadata
+import com.hortonworks.spark.atlas.utils.SparkUtils
+import org.apache.atlas.model.instance.AtlasEntity
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.execution.datasources.v2.{InternalRowDataWriterFactory, WriteToDataSourceV2Exec}
+import org.apache.spark.sql.execution.streaming.sources.{InternalRowMicroBatchWriter, MemoryWriterFactory}
+import org.apache.spark.sql.kafka010.{KafkaStreamWriter, KafkaTestUtils}
+import org.apache.spark.sql.sources.v2.writer.{DataWriterFactory, SupportsWriteInternalRow, WriterCommitMessage}
+import org.apache.spark.sql.sources.v2.writer.streaming.StreamWriter
+import org.apache.spark.sql.streaming.{OutputMode, StreamTest, StreamingQuery}
+import org.apache.spark.sql.types.{BinaryType, StructType}
+import org.apache.spark.sql.util.QueryExecutionListener
+
+import scala.collection.convert.Wrappers.SeqWrapper
+import scala.collection.mutable
+
+class KafkaHarvesterSuite extends StreamTest {
+  val brokerProps = Map[String, Object]()
+
+  val producerParams = Map[String, String]()
+  val kafkaWriteSchema = new StructType().add("value", BinaryType)
+
+  var testUtils: KafkaTestUtils = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    testUtils = new KafkaTestUtils(brokerProps)
+    testUtils.setup()
+  }
+
+  override def afterAll(): Unit = {
+    if (testUtils != null) {
+      testUtils.teardown()
+      testUtils = null
+    }
+    super.afterAll()
+  }
+
+  test("Extract Kafka topic from InternalRowMicroBatchWriter") {
+    val topic = Some("hello")
+
+    val writer = new KafkaStreamWriter(topic, producerParams, kafkaWriteSchema)
+    val microBatchWriter = new InternalRowMicroBatchWriter(0L, writer)
+
+    assert(KafkaHarvester.extractTopic(microBatchWriter) === (true, topic))
+  }
+
+  test("No Kafka topic information in WriterFactory") {
+    val writer = new FakeStreamWriter()
+    val microBatchWriter = new InternalRowMicroBatchWriter(0L, writer)
+
+    assert(KafkaHarvester.extractTopic(microBatchWriter) === (false, None))
+  }
+
+  private class AtlasQueryExecutionListener extends QueryExecutionListener {
+    private val executionId = new AtomicLong(0L)
+    val queryDetails = new mutable.MutableList[QueryDetail]()
+
+    override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
+      queryDetails += QueryDetail(qe, executionId.getAndIncrement(), durationNs)
+    }
+
+    override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {
+      fail(exception)
+    }
+  }
+
+  test("Streaming query with Kafka source and sink") {
+    def sendMessages(topicsToRead: Seq[String]): Unit = {
+      topicsToRead.foreach { topic =>
+        testUtils.sendMessages(topic, Array("1", "2", "3", "4", "5"))
+      }
+    }
+
+    def waitForBatchCompleted(query: StreamingQuery, listener: AtlasQueryExecutionListener)
+      : Unit = {
+      import org.scalatest.time.SpanSugar._
+      eventually(timeout(10.seconds)) {
+        query.processAllAvailable()
+        assert(listener.queryDetails.nonEmpty)
+      }
+    }
+
+    def executeHarvest(qd: QueryDetail): Seq[AtlasEntity] = {
+      val execAndTopic = qd.qe.sparkPlan.flatMap {
+        case r: WriteToDataSourceV2Exec =>
+          r.writer match {
+            case w: InternalRowMicroBatchWriter =>
+              val (isKafkaTopic, topic) = KafkaHarvester.extractTopic(w)
+              if (isKafkaTopic) {
+                Seq((r, topic))
+              } else {
+                Seq.empty
+              }
+
+            case _ => Nil
+          }
+
+        case _ => Nil
+      }
+
+      assert(execAndTopic.size == 1)
+      val (exec, topic) = execAndTopic.head
+
+      KafkaHarvester.harvest(topic, exec, qd)
+    }
+
+    def assertEntitiesKafkaTopicType(topics: Seq[String], entities: Seq[AtlasEntity]): Unit = {
+      val kafkaTopicEntities = entities.filter(p => p.getTypeName.equals(KAFKA_TOPIC_STRING))
+
+      assert(kafkaTopicEntities.size === topics.size)
+      assert(kafkaTopicEntities.map(_.getAttribute("name").toString()).toSet === topics.toSet)
+      assert(kafkaTopicEntities.map(_.getAttribute("topic").toString()).toSet === topics.toSet)
+      assert(kafkaTopicEntities.map(_.getAttribute("uri").toString()).toSet === topics.toSet)
+    }
+
+    def assertEntitySparkProcessType(topicsToRead: Seq[String], topicToWrite: String,
+                                     entities: Seq[AtlasEntity], queryDetail: QueryDetail): Unit = {
+      val processEntities = entities.filter { p =>
+        p.getTypeName.equals(metadata.PROCESS_TYPE_STRING)
+      }
+
+      assert(processEntities.size === 1)
+      val processEntity = processEntities.head
+
+      val inputs = processEntity.getAttribute("inputs")
+        .asInstanceOf[SeqWrapper[AtlasEntity]].underlying
+      val outputs = processEntity.getAttribute("outputs")
+        .asInstanceOf[SeqWrapper[AtlasEntity]].underlying
+
+      assert(!inputs.exists(_.getTypeName != KAFKA_TOPIC_STRING))
+      assert(!outputs.exists(_.getTypeName != KAFKA_TOPIC_STRING))
+
+      assert(inputs.map(_.getAttribute("name")).toSet === topicsToRead.toSet)
+      assert(outputs.map(_.getAttribute("name")).toSet === Seq(topicToWrite).toSet)
+
+      // verify others
+      val expectedMap = Map(
+        "executionId" -> queryDetail.executionId.toString,
+        "remoteUser" -> SparkUtils.currSessionUser(queryDetail.qe),
+        "executionTime" -> queryDetail.executionTime.toString,
+        "details" -> queryDetail.qe.toString()
+      )
+
+      expectedMap.foreach { case (key, value) =>
+        assert(processEntity.getAttribute(key) === value)
+      }
+    }
+
+    val topicsToRead = Seq("sparkread1", "sparkread2", "sparkread3")
+    val topicToWrite = "sparkwrite"
+    val topics = topicsToRead :+ topicToWrite
+
+    val brokerAddress = testUtils.brokerAddress
+
+    topics.foreach(testUtils.createTopic(_, 10, overwrite = true))
+
+    val listener = new AtlasQueryExecutionListener
+    spark.listenerManager.register(listener)
+
+    val tempDir = Files.createTempDirectory("spark-atlas-kafka-harvester")
+
+    val df = spark.readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", brokerAddress)
+      .option("subscribe", topicsToRead.mkString(","))
+      .option("startingOffsets", "earliest")
+      .load()
+
+    val query = df.writeStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", brokerAddress)
+      .option("topic", topicToWrite)
+      .option("checkpointLocation", tempDir.toAbsolutePath.toString)
+      .start()
+
+    // remove temporary directory in shutdown
+    org.apache.hadoop.util.ShutdownHookManager.get().addShutdownHook(
+      new Runnable {
+        override def run(): Unit = {
+          Files.deleteIfExists(tempDir)
+        }
+      }, 10)
+
+    try {
+      sendMessages(topicsToRead)
+      waitForBatchCompleted(query, listener)
+
+      val queryDetail = listener.queryDetails.head
+      val atlasEntities = executeHarvest(queryDetail)
+
+      assertEntitiesKafkaTopicType(topics, atlasEntities)
+      assertEntitySparkProcessType(topicsToRead, topicToWrite, atlasEntities, queryDetail)
+    } finally {
+      query.stop()
+    }
+  }
+
+  private class FakeStreamWriter extends StreamWriter with SupportsWriteInternalRow {
+    override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}
+
+    override def abort(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}
+
+    override def createWriterFactory(): DataWriterFactory[Row] = {
+      MemoryWriterFactory(OutputMode.Append())
+    }
+
+    override def createInternalRowWriterFactory(): DataWriterFactory[InternalRow] = {
+      new InternalRowDataWriterFactory(MemoryWriterFactory(OutputMode.Append()), kafkaWriteSchema)
+    }
+  }
+
+}

--- a/spark-atlas-connector/src/test/scala/org/apache/spark/sql/kafka010/atlas/KafkaHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/org/apache/spark/sql/kafka010/atlas/KafkaHarvesterSuite.scala
@@ -17,17 +17,8 @@
 
 package org.apache.spark.sql.kafka010.atlas
 
-import java.nio.file.Files
-import java.util.concurrent.atomic.AtomicLong
-
-import com.hortonworks.spark.atlas.sql.QueryDetail
-import com.hortonworks.spark.atlas.types.external.KAFKA_TOPIC_STRING
-import com.hortonworks.spark.atlas.types.metadata
-import com.hortonworks.spark.atlas.utils.SparkUtils
-import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.datasources.v2.{InternalRowDataWriterFactory, WriteToDataSourceV2Exec}
 import org.apache.spark.sql.execution.streaming.sources.{InternalRowMicroBatchWriter, MemoryWriterFactory}
 import org.apache.spark.sql.kafka010.{KafkaStreamWriter, KafkaTestUtils}
@@ -35,10 +26,6 @@ import org.apache.spark.sql.sources.v2.writer.{DataWriterFactory, SupportsWriteI
 import org.apache.spark.sql.sources.v2.writer.streaming.StreamWriter
 import org.apache.spark.sql.streaming.{OutputMode, StreamTest, StreamingQuery}
 import org.apache.spark.sql.types.{BinaryType, StructType}
-import org.apache.spark.sql.util.QueryExecutionListener
-
-import scala.collection.convert.Wrappers.SeqWrapper
-import scala.collection.mutable
 
 class KafkaHarvesterSuite extends StreamTest {
   val brokerProps = Map[String, Object]()
@@ -69,157 +56,6 @@ class KafkaHarvesterSuite extends StreamTest {
     val microBatchWriter = new InternalRowMicroBatchWriter(0L, writer)
 
     assert(KafkaHarvester.extractTopic(microBatchWriter) === (true, topic))
-  }
-
-  test("No Kafka topic information in WriterFactory") {
-    val writer = new FakeStreamWriter()
-    val microBatchWriter = new InternalRowMicroBatchWriter(0L, writer)
-
-    assert(KafkaHarvester.extractTopic(microBatchWriter) === (false, None))
-  }
-
-  private class AtlasQueryExecutionListener extends QueryExecutionListener {
-    private val executionId = new AtomicLong(0L)
-    val queryDetails = new mutable.MutableList[QueryDetail]()
-
-    override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
-      queryDetails += QueryDetail(qe, executionId.getAndIncrement(), durationNs)
-    }
-
-    override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {
-      fail(exception)
-    }
-  }
-
-  test("Streaming query with Kafka source and sink") {
-    def sendMessages(topicsToRead: Seq[String]): Unit = {
-      topicsToRead.foreach { topic =>
-        testUtils.sendMessages(topic, Array("1", "2", "3", "4", "5"))
-      }
-    }
-
-    def waitForBatchCompleted(query: StreamingQuery, listener: AtlasQueryExecutionListener)
-      : Unit = {
-      import org.scalatest.time.SpanSugar._
-      eventually(timeout(10.seconds)) {
-        query.processAllAvailable()
-        assert(listener.queryDetails.nonEmpty)
-      }
-    }
-
-    def executeHarvest(qd: QueryDetail): Seq[AtlasEntity] = {
-      val execAndTopic = qd.qe.sparkPlan.flatMap {
-        case r: WriteToDataSourceV2Exec =>
-          r.writer match {
-            case w: InternalRowMicroBatchWriter =>
-              val (isKafkaTopic, topic) = KafkaHarvester.extractTopic(w)
-              if (isKafkaTopic) {
-                Seq((r, topic))
-              } else {
-                Seq.empty
-              }
-
-            case _ => Nil
-          }
-
-        case _ => Nil
-      }
-
-      assert(execAndTopic.size == 1)
-      val (exec, topic) = execAndTopic.head
-
-      KafkaHarvester.harvest(topic, exec, qd)
-    }
-
-    def assertEntitiesKafkaTopicType(topics: Seq[String], entities: Seq[AtlasEntity]): Unit = {
-      val kafkaTopicEntities = entities.filter(p => p.getTypeName.equals(KAFKA_TOPIC_STRING))
-
-      assert(kafkaTopicEntities.size === topics.size)
-      assert(kafkaTopicEntities.map(_.getAttribute("name").toString()).toSet === topics.toSet)
-      assert(kafkaTopicEntities.map(_.getAttribute("topic").toString()).toSet === topics.toSet)
-      assert(kafkaTopicEntities.map(_.getAttribute("uri").toString()).toSet === topics.toSet)
-    }
-
-    def assertEntitySparkProcessType(topicsToRead: Seq[String], topicToWrite: String,
-                                     entities: Seq[AtlasEntity], queryDetail: QueryDetail): Unit = {
-      val processEntities = entities.filter { p =>
-        p.getTypeName.equals(metadata.PROCESS_TYPE_STRING)
-      }
-
-      assert(processEntities.size === 1)
-      val processEntity = processEntities.head
-
-      val inputs = processEntity.getAttribute("inputs")
-        .asInstanceOf[SeqWrapper[AtlasEntity]].underlying
-      val outputs = processEntity.getAttribute("outputs")
-        .asInstanceOf[SeqWrapper[AtlasEntity]].underlying
-
-      assert(!inputs.exists(_.getTypeName != KAFKA_TOPIC_STRING))
-      assert(!outputs.exists(_.getTypeName != KAFKA_TOPIC_STRING))
-
-      assert(inputs.map(_.getAttribute("name")).toSet === topicsToRead.toSet)
-      assert(outputs.map(_.getAttribute("name")).toSet === Seq(topicToWrite).toSet)
-
-      // verify others
-      val expectedMap = Map(
-        "executionId" -> queryDetail.executionId.toString,
-        "remoteUser" -> SparkUtils.currSessionUser(queryDetail.qe),
-        "executionTime" -> queryDetail.executionTime.toString,
-        "details" -> queryDetail.qe.toString()
-      )
-
-      expectedMap.foreach { case (key, value) =>
-        assert(processEntity.getAttribute(key) === value)
-      }
-    }
-
-    val topicsToRead = Seq("sparkread1", "sparkread2", "sparkread3")
-    val topicToWrite = "sparkwrite"
-    val topics = topicsToRead :+ topicToWrite
-
-    val brokerAddress = testUtils.brokerAddress
-
-    topics.foreach(testUtils.createTopic(_, 10, overwrite = true))
-
-    val listener = new AtlasQueryExecutionListener
-    spark.listenerManager.register(listener)
-
-    val tempDir = Files.createTempDirectory("spark-atlas-kafka-harvester")
-
-    val df = spark.readStream
-      .format("kafka")
-      .option("kafka.bootstrap.servers", brokerAddress)
-      .option("subscribe", topicsToRead.mkString(","))
-      .option("startingOffsets", "earliest")
-      .load()
-
-    val query = df.writeStream
-      .format("kafka")
-      .option("kafka.bootstrap.servers", brokerAddress)
-      .option("topic", topicToWrite)
-      .option("checkpointLocation", tempDir.toAbsolutePath.toString)
-      .start()
-
-    // remove temporary directory in shutdown
-    org.apache.hadoop.util.ShutdownHookManager.get().addShutdownHook(
-      new Runnable {
-        override def run(): Unit = {
-          Files.deleteIfExists(tempDir)
-        }
-      }, 10)
-
-    try {
-      sendMessages(topicsToRead)
-      waitForBatchCompleted(query, listener)
-
-      val queryDetail = listener.queryDetails.head
-      val atlasEntities = executeHarvest(queryDetail)
-
-      assertEntitiesKafkaTopicType(topics, atlasEntities)
-      assertEntitySparkProcessType(topicsToRead, topicToWrite, atlasEntities, queryDetail)
-    } finally {
-      query.stop()
-    }
   }
 
   private class FakeStreamWriter extends StreamWriter with SupportsWriteInternalRow {


### PR DESCRIPTION
* Modify the changeset of #80 to work along with Spark 2.3.x
* Also add UTs for KafkaHarvester

Please check the difference between this patch and #80 : Micro-batch source of Kafka connector relies on DSv1, while continuous source relies on DSv2. Moreover there's some difference on DSv2 (Spark 2.4 sorted out some odd things like `InternalRowXXX`.)

While I added code for continuous mode, I don't expect continuous mode to trigger listener to get executed plan (it will not be finished), so spark-atlas can't work with continuous mode.