### PR TITLE
[SAC-83] Use Spark Catalog

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -111,11 +111,11 @@ object external {
     Seq(kafkaEntity)
   }
 
-  // ================== Hive entities =====================
-  val HIVE_DB_TYPE_STRING = "hive_db"
-  val HIVE_STORAGEDESC_TYPE_STRING = "hive_storagedesc"
-  val HIVE_COLUMN_TYPE_STRING = "hive_column"
-  val HIVE_TABLE_TYPE_STRING = "hive_table"
+  // ================== Spark's Hive Catalog entities =====================
+  val HIVE_DB_TYPE_STRING = "spark_db"
+  val HIVE_STORAGEDESC_TYPE_STRING = "spark_storagedesc"
+  val HIVE_COLUMN_TYPE_STRING = "spark_column"
+  val HIVE_TABLE_TYPE_STRING = "spark_table"
 
   def hiveDbUniqueAttribute(cluster: String, db: String): String = s"${db.toLowerCase}@$cluster"
 

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.execution.UnionExec
 import org.apache.spark.sql.hive.execution.InsertIntoHiveTable
 import org.scalatest.{Matchers, FunSuite}
 
-import com.hortonworks.spark.atlas.types.external
+import com.hortonworks.spark.atlas.types.{metadata, external}
 import com.hortonworks.spark.atlas.WithHiveSupport
 
 
@@ -137,7 +137,7 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
     inputs.size() should be (1)
 
     val inputTbl = inputs.asScala.head
-    inputTbl.getTypeName should not be external.HIVE_TABLE_TYPE_STRING
+    inputTbl.getTypeName should be (metadata.TABLE_TYPE_STRING)
     inputTbl.getAttribute("name") should be (sourceSparkTblName)
     inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
       s"$dataBase.$sourceSparkTblName")
@@ -179,7 +179,7 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
     val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
     outputs.size() should be (1)
     val outputTbl = outputs.asScala.head
-    outputTbl.getTypeName should not be external.HIVE_TABLE_TYPE_STRING
+    outputTbl.getTypeName should be (metadata.TABLE_TYPE_STRING)
     outputTbl.getAttribute("name") should be (destinationSparkTblName)
     outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
       s"$dataBase.$destinationSparkTblName")
@@ -203,7 +203,7 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
     inputs.size() should be (1)
 
     val inputTbl = inputs.asScala.head
-    inputTbl.getTypeName should not be external.HIVE_TABLE_TYPE_STRING
+    inputTbl.getTypeName should be (metadata.TABLE_TYPE_STRING)
     inputTbl.getAttribute("name") should be (sourceSparkTblName)
     inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
       s"$dataBase.$sourceSparkTblName")
@@ -212,7 +212,7 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
     val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
     outputs.size() should be (1)
     val outputTbl = outputs.asScala.head
-    outputTbl.getTypeName should not be external.HIVE_TABLE_TYPE_STRING
+    outputTbl.getTypeName should be (metadata.TABLE_TYPE_STRING)
     outputTbl.getAttribute("name") should be (destinationSparkTblName)
     outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
       s"$dataBase.$destinationSparkTblName")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hive Metastore provides multiple Catalogs. SAC assumes that it has own `spark` catalog which consists of fully accessible non-transactional tables. `spark` catalog is new one which is created by the following method.

https://cwiki.apache.org/confluence/display/Hive/Hive+Schema+Tool

```bash
$ schematool \
  -dbType mysql \
  -createCatalog spark \
  -catalogDescription 'Default catalog, for Spark' \
  -catalogLocation hdfs://cluster:8020/apps/spark/warehouse
```

## How was this patch tested?

UTs are modified and this is also tested with Apache Spark 2.4.0 and Atlas 1.1.0 with embedded HBase/Solr manually.

This closes #83 .