### PR TITLE
[SAC-87] Support `atlas.spark.enabled` configuration

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClientConf.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClientConf.scala
@@ -17,8 +17,6 @@
 
 package com.hortonworks.spark.atlas
 
-import java.util
-
 import org.apache.atlas.ApplicationProperties
 import com.hortonworks.spark.atlas.AtlasClientConf.ConfigEntry
 
@@ -55,6 +53,8 @@ class AtlasClientConf {
 
 object AtlasClientConf {
   case class ConfigEntry(key: String, defaultValue: String)
+
+  val ATLAS_SPARK_ENABLED = ConfigEntry("atlas.spark.enabled", "true")
 
   val ATLAS_REST_ENDPOINT = ConfigEntry("atlas.rest.address", "localhost:21000")
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/SparkAtlasEventTracker.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/SparkAtlasEventTracker.scala
@@ -94,6 +94,10 @@ class SparkAtlasEventTracker(atlasClient: AtlasClient, atlasClientConf: AtlasCli
   }
 
   private def initializeSparkModel(): Boolean = {
+    if (!atlasClientConf.get(AtlasClientConf.ATLAS_SPARK_ENABLED).toBoolean) {
+      logWarn("Spark Atlas Connector is disabled.")
+      return false
+    }
     try {
       val checkModelInStart = atlasClientConf.get(AtlasClientConf.CHECK_MODEL_IN_START).toBoolean
       if (checkModelInStart) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR supports `atlas.spark.enabled`. If `atlas.spark.enabled` is `false` in `atlas-application.properties`, Spark Atlas Connector will not populate Spark-related Atlas model and not create Spark entity create events.

The default value of `atlas.spark.enabled` is `true` because the users already register Spark Atlas Listners.

## How was this patch tested?

Manually tested with Apache Atlas 1.1.0 (embedded HBase/Solr).