### PR TITLE
[SAC-89] SAC should not warn on query failures

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/SparkAtlasEventTracker.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/SparkAtlasEventTracker.scala
@@ -90,7 +90,7 @@ class SparkAtlasEventTracker(atlasClient: AtlasClient, atlasClientConf: AtlasCli
   }
 
   override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {
-    logWarn(s"Fail to execute query: {$qe}, {$funcName}", exception)
+    // No-op: SAC is one of the listener.
   }
 
   private def initializeSparkModel(): Boolean = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, SAC repeats Spark's warning on query failures. Since SAC is one of the listeners, we had better be silent.

## How was this patch tested?

Manual with Apache Atlas 1.1.0 (with embedded HBase/Solr) and Apache Spark 2.4.0.

This closes #89 