### PR TITLE
[SAC-94] Fix df.write.saveAsTable to be correctly logged to Atlas (atlas-1.1)

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
@@ -52,10 +52,6 @@ class SparkExecutionPlanProcessor(
             logDebug(s"LOAD DATA [LOCAL] INPATH (${c.path}) ${c.table}")
             CommandsHarvester.LoadDataHarvester.harvest(c, qd)
 
-          case c: CreateDataSourceTableAsSelectCommand =>
-            logDebug(s"CREATE TABLE USING xx AS SELECT query: ${qd.qe}")
-            CommandsHarvester.CreateDataSourceTableAsSelectHarvester.harvest(c, qd)
-
           case c: CreateViewCommand =>
             logDebug(s"CREATE VIEW AS SELECT query: ${qd.qe}")
             CommandsHarvester.CreateViewHarvester.harvest(c, qd)
@@ -81,6 +77,10 @@ class SparkExecutionPlanProcessor(
           case c: CreateHiveTableAsSelectCommand =>
             logDebug(s"CREATE TABLE AS SELECT query: ${qd.qe}")
             CommandsHarvester.CreateHiveTableAsSelectHarvester.harvest(c, qd)
+
+          case c: CreateDataSourceTableAsSelectCommand =>
+            logDebug(s"CREATE TABLE USING xx AS SELECT query: ${qd.qe}")
+            CommandsHarvester.CreateDataSourceTableAsSelectHarvester.harvest(c, qd)
 
           case _ =>
             Seq.empty

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForBatchQuerySuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForBatchQuerySuite.scala
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql
+
+import java.io.{BufferedWriter, FileWriter}
+import java.nio.file.{Files, Path}
+import java.util.Locale
+
+import com.hortonworks.spark.atlas.sql.testhelper.{AtlasQueryExecutionListener, CreateEntitiesTrackingAtlasClient, DirectProcessSparkExecutionPlanProcessor}
+import com.hortonworks.spark.atlas.types.{external, metadata}
+import com.hortonworks.spark.atlas.utils.SparkUtils
+import com.hortonworks.spark.atlas.AtlasClientConf
+import org.apache.atlas.model.instance.AtlasEntity
+import org.apache.spark.sql.streaming.StreamTest
+
+class SparkExecutionPlanProcessorForBatchQuerySuite extends StreamTest {
+  import com.hortonworks.spark.atlas.sql.testhelper.AtlasEntityReadHelper._
+
+  val atlasClientConf: AtlasClientConf = new AtlasClientConf()
+    .set(AtlasClientConf.CHECK_MODEL_IN_START.key, "false")
+  var atlasClient: CreateEntitiesTrackingAtlasClient = _
+  val testHelperQueryListener = new AtlasQueryExecutionListener()
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    atlasClient = new CreateEntitiesTrackingAtlasClient()
+    testHelperQueryListener.clear()
+    spark.listenerManager.register(testHelperQueryListener)
+  }
+
+  override def afterAll(): Unit = {
+    atlasClient = null
+    spark.listenerManager.unregister(testHelperQueryListener)
+    super.afterAll()
+  }
+
+  test("Read csv file and save as table") {
+    val planProcessor = new DirectProcessSparkExecutionPlanProcessor(atlasClient, atlasClientConf)
+
+    val csvContent = Seq("a,1", "b,2", "c,3", "d,4").mkString("\n")
+    val tempFile: Path = writeCSVtextToTempFile(csvContent)
+
+    val rand = new scala.util.Random()
+    val outputTableName = "app_details_" + rand.nextInt(1000000000)
+
+    val df = spark.read.csv(tempFile.toAbsolutePath.toString)
+    df.write.saveAsTable(outputTableName)
+
+    val queryDetail = testHelperQueryListener.queryDetails.last
+    planProcessor.process(queryDetail)
+    val entities = atlasClient.createdEntities
+
+    val tableEntity: AtlasEntity = getOnlyOneEntity(entities, metadata.TABLE_TYPE_STRING)
+
+    // only assert qualifiedName and skip assertion on database, and attributes on database
+    // they should be covered in other UT
+    val tableQualifiedName = getStringAttribute(tableEntity, "qualifiedName")
+    assert(tableQualifiedName.endsWith(outputTableName))
+
+    // remove table name + '.' prior to table name
+    val databaseQualifiedName = tableQualifiedName.substring(0,
+      tableQualifiedName.indexOf(outputTableName) - 1)
+
+    val databaseEntity = getOnlyOneEntity(entities, metadata.DB_TYPE_STRING)
+    assert(getStringAttribute(databaseEntity, "qualifiedName") === databaseQualifiedName)
+
+    // database entity in table entity should be same as outer database entity
+    val databaseEntityInTable = getAtlasEntityAttribute(tableEntity, "database")
+    assert(databaseEntity === databaseEntityInTable)
+
+    val databaseLocationFsEntity = getAtlasEntityAttribute(databaseEntity, "locationUri")
+
+    // we're expecting two file system entities:
+    // one for input file, another one for database warehouse
+    val fsEntities = listAtlasEntitiesAsType(entities, external.FS_PATH_TYPE_STRING)
+    assert(fsEntities.size === 2)
+
+    // database warehouse
+    assert(fsEntities.contains(databaseLocationFsEntity))
+
+    val inputFsEntities = fsEntities.filterNot(_ == databaseLocationFsEntity)
+    assert(inputFsEntities.size === 1)
+
+    // input file
+    val inputFsEntity = inputFsEntities.head
+
+    assertPathsEquals(getStringAttribute(inputFsEntity, "name"), tempFile.toAbsolutePath.toString)
+    assertPathsEquals(getStringAttribute(inputFsEntity, "path"), tempFile.toAbsolutePath.toString)
+    assertPathsEquals(getStringAttribute(inputFsEntity, "qualifiedName"),
+      "file://" + tempFile.toAbsolutePath.toString)
+
+    // check for 'spark_process'
+    val processEntity = getOnlyOneEntity(entities, metadata.PROCESS_TYPE_STRING)
+
+    val inputs = getSeqAtlasEntityAttribute(processEntity, "inputs")
+    val outputs = getSeqAtlasEntityAttribute(processEntity, "outputs")
+
+    val input = getOnlyOneEntity(inputs, external.FS_PATH_TYPE_STRING)
+    val output = getOnlyOneEntity(outputs, metadata.TABLE_TYPE_STRING)
+
+    // input/output in 'spark_process' should be same as outer entities
+    assert(input === inputFsEntity)
+    assert(output === tableEntity)
+
+    val expectedMap = Map(
+      "executionId" -> queryDetail.executionId.toString,
+      "remoteUser" -> SparkUtils.currSessionUser(queryDetail.qe),
+      "executionTime" -> queryDetail.executionTime.toString,
+      "details" -> queryDetail.qe.toString()
+    )
+
+    expectedMap.foreach { case (key, value) =>
+      assert(processEntity.getAttribute(key) === value)
+    }
+  }
+
+  private def writeCSVtextToTempFile(csvContent: String) = {
+    val tempFile = Files.createTempFile("spark-atlas-connector-csv-temp", ".csv")
+
+    // remove temporary file in shutdown
+    org.apache.hadoop.util.ShutdownHookManager.get().addShutdownHook(
+      new Runnable {
+        override def run(): Unit = {
+          Files.deleteIfExists(tempFile)
+        }
+      }, 10)
+
+    val bw = new BufferedWriter(new FileWriter(tempFile.toFile))
+    bw.write(csvContent)
+    bw.close()
+    tempFile
+  }
+
+  private def assertPathsEquals(path1: String, path2: String): Unit = {
+    // we are comparing paths with lower case, since we may want to run the test
+    // from case-insensitive filesystem
+    assert(path1.toLowerCase(Locale.ROOT) === path2.toLowerCase(Locale.ROOT))
+  }
+}

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/AtlasEntityReadHelper.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/AtlasEntityReadHelper.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql.testhelper
+
+import org.apache.atlas.model.instance.AtlasEntity
+import scala.collection.convert.Wrappers.SeqWrapper
+
+object AtlasEntityReadHelper {
+  def listAtlasEntitiesAsType(entities: Seq[AtlasEntity], typeStr: String): Seq[AtlasEntity] = {
+    entities.filter(p => p.getTypeName.equals(typeStr))
+  }
+
+  def getOnlyOneEntity(entities: Seq[AtlasEntity], typeStr: String): AtlasEntity = {
+    val filteredEntities = entities.filter { p =>
+      p.getTypeName.equals(typeStr)
+    }
+    assert(filteredEntities.size == 1)
+    filteredEntities.head
+  }
+
+  def getStringAttribute(entity: AtlasEntity, attrName: String): String = {
+    entity.getAttribute(attrName).asInstanceOf[String]
+  }
+
+  def getAtlasEntityAttribute(entity: AtlasEntity, attrName: String): AtlasEntity = {
+    entity.getAttribute(attrName).asInstanceOf[AtlasEntity]
+  }
+
+  def getSeqAtlasEntityAttribute(entity: AtlasEntity, attrName: String)
+  : Seq[AtlasEntity] = {
+    entity.getAttribute(attrName).asInstanceOf[SeqWrapper[AtlasEntity]].underlying
+  }
+}

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/AtlasQueryExecutionListener.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/AtlasQueryExecutionListener.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql.testhelper
+
+import java.util.concurrent.atomic.AtomicLong
+
+import com.hortonworks.spark.atlas.sql.QueryDetail
+import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.util.QueryExecutionListener
+
+import scala.collection.mutable
+
+class AtlasQueryExecutionListener extends QueryExecutionListener {
+  private val executionId = new AtomicLong(0L)
+  val queryDetails = new mutable.MutableList[QueryDetail]()
+
+  override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
+    queryDetails += QueryDetail(qe, executionId.getAndIncrement(), durationNs)
+  }
+
+  override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {
+    throw exception
+  }
+
+  def clear(): Unit = {
+    queryDetails.clear()
+  }
+}

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/CreateEntitiesTrackingAtlasClient.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/CreateEntitiesTrackingAtlasClient.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql.testhelper
+
+import com.hortonworks.spark.atlas.AtlasClient
+import com.sun.jersey.core.util.MultivaluedMapImpl
+import org.apache.atlas.model.instance.AtlasEntity
+import org.apache.atlas.model.typedef.AtlasTypesDef
+
+import scala.collection.mutable
+
+class CreateEntitiesTrackingAtlasClient extends AtlasClient {
+  val createdEntities = new mutable.ListBuffer[AtlasEntity]()
+
+  override def createAtlasTypeDefs(typeDefs: AtlasTypesDef): Unit = {}
+
+  override def getAtlasTypeDefs(searchParams: MultivaluedMapImpl): AtlasTypesDef = {
+    new AtlasTypesDef()
+  }
+
+  override def updateAtlasTypeDefs(typeDefs: AtlasTypesDef): Unit = {}
+
+  override protected def doCreateEntities(entities: Seq[AtlasEntity]): Unit = {
+    createdEntities ++= entities
+  }
+
+  override protected def doDeleteEntityWithUniqueAttr(entityType: String,
+                                                      attribute: String): Unit = {}
+
+  override protected def doUpdateEntityWithUniqueAttr(entityType: String, attribute: String,
+                                                      entity: AtlasEntity): Unit = {}
+}

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/DirectProcessSparkExecutionPlanProcessor.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/DirectProcessSparkExecutionPlanProcessor.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql.testhelper
+
+import com.hortonworks.spark.atlas.sql.{QueryDetail, SparkExecutionPlanProcessor}
+import com.hortonworks.spark.atlas.{AtlasClient, AtlasClientConf}
+
+class DirectProcessSparkExecutionPlanProcessor(
+    atlasClient: AtlasClient,
+    atlasClientConf: AtlasClientConf)
+  extends SparkExecutionPlanProcessor(atlasClient, atlasClientConf) {
+
+  override def process(qd: QueryDetail): Unit = super.process(qd)
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fixes the bug which doesn't register entities to Atlas for below query:

```
val df = spark.read.csv("abc.csv")
df.write.saveAsTable("app_details_spark_2_3")
``` 

After applying the patch, SAC correctly registers Atlas entities: spark_process, spark_db, spark_table, fs_path.

## How was this patch tested?

* Added UT
* Manually verified with Atlas 1.1 (local HBase, local Solr) & Spark 2.3