### PR TITLE
[SAC-101][SQL] Add `atlas.spark.column.enabled` configuration

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClientConf.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClientConf.scala
@@ -55,6 +55,7 @@ object AtlasClientConf {
   case class ConfigEntry(key: String, defaultValue: String)
 
   val ATLAS_SPARK_ENABLED = ConfigEntry("atlas.spark.enabled", "true")
+  val ATLAS_SPARK_COLUMN_ENABLED = ConfigEntry("atlas.spark.column.enabled", "true")
 
   val ATLAS_REST_ENDPOINT = ConfigEntry("atlas.rest.address", "localhost:21000")
 

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessorSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessorSuite.scala
@@ -120,15 +120,19 @@ class SparkCatalogEventProcessorSuite extends FunSuite with Matchers with Before
     eventually(timeout(30 seconds), interval(100 milliseconds)) {
       assert(atlasClient.createEntityCall(processor.dbType) == 1)
       assert(atlasClient.createEntityCall(processor.tableType(isHiveTbl)) == 1)
-      assert(atlasClient.createEntityCall(processor.columnType(isHiveTbl)) == 1)
-      assert(atlasClient.createEntityCall(processor.storageFormatType(isHiveTbl)) == 1)
+      if (atlasClientConf.get(AtlasClientConf.ATLAS_SPARK_COLUMN_ENABLED).toBoolean) {
+        assert(atlasClient.createEntityCall(processor.columnType(isHiveTbl)) == 1)
+        assert(atlasClient.createEntityCall(processor.storageFormatType(isHiveTbl)) == 1)
+      }
     }
 
     SparkUtils.getExternalCatalog().renameTable("db1", "tbl1", "tbl2")
     processor.pushEvent(RenameTableEvent("db1", "tbl1", "tbl2"))
     eventually(timeout(30 seconds), interval(100 milliseconds)) {
-      assert(atlasClient.updateEntityCall(processor.storageFormatType(isHiveTbl)) == 1)
-      assert(atlasClient.updateEntityCall(processor.columnType(isHiveTbl)) == 1)
+      if (atlasClientConf.get(AtlasClientConf.ATLAS_SPARK_COLUMN_ENABLED).toBoolean) {
+        assert(atlasClient.updateEntityCall(processor.storageFormatType(isHiveTbl)) == 1)
+        assert(atlasClient.updateEntityCall(processor.columnType(isHiveTbl)) == 1)
+      }
       assert(atlasClient.updateEntityCall(processor.tableType(isHiveTbl)) == 1)
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to add `atlas.spark.column.enabled` configuration.

## How was this patch tested?

Pass the Travis CI with the updated test cases.

This is also tested manually with Apache Atlas 1.1.0 and Apache Spark 2.4.0.

This closes #101 