### PR TITLE
[SAC-103] Support custom atlas cluster name for Kafka topics (source/sink)

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -22,7 +22,6 @@ import java.net.{URI, URISyntaxException}
 import java.util.Date
 
 import scala.collection.JavaConverters._
-
 import org.apache.atlas.AtlasConstants
 import org.apache.atlas.hbase.bridge.HBaseAtlasHook._
 import org.apache.atlas.model.instance.AtlasEntity
@@ -31,8 +30,8 @@ import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogStorageFormat, CatalogTable}
 import org.apache.spark.sql.types.StructType
-
 import com.hortonworks.spark.atlas.utils.SparkUtils
+import org.apache.spark.sql.kafka010.atlas.KafkaTopicInformation
 
 object external {
   // External metadata types used to link with external entities
@@ -100,14 +99,19 @@ object external {
   // ================ Kafka entities =======================
   val KAFKA_TOPIC_STRING = "kafka_topic"
 
-  def kafkaToEntity(cluster: String, topicName: String): Seq[AtlasEntity] = {
+  def kafkaToEntity(cluster: String, topic: KafkaTopicInformation): Seq[AtlasEntity] = {
+    val topicName = topic.topicName.toLowerCase
+    val clusterName = topic.clusterName match {
+      case Some(customName) => customName
+      case None => cluster
+    }
+
     val kafkaEntity = new AtlasEntity(KAFKA_TOPIC_STRING)
-    kafkaEntity.setAttribute("qualifiedName",
-      topicName.toLowerCase + '@' + cluster)
-    kafkaEntity.setAttribute("name", topicName.toLowerCase)
-    kafkaEntity.setAttribute(AtlasConstants.CLUSTER_NAME_ATTRIBUTE, cluster)
-    kafkaEntity.setAttribute("uri", topicName.toLowerCase)
-    kafkaEntity.setAttribute("topic", topicName.toLowerCase)
+    kafkaEntity.setAttribute("qualifiedName", topicName + '@' + clusterName)
+    kafkaEntity.setAttribute("name", topicName)
+    kafkaEntity.setAttribute(AtlasConstants.CLUSTER_NAME_ATTRIBUTE, clusterName)
+    kafkaEntity.setAttribute("uri", topicName)
+    kafkaEntity.setAttribute("topic", topicName)
     Seq(kafkaEntity)
   }
 

--- a/spark-atlas-connector/src/main/scala/org/apache/spark/sql/kafka010/atlas/KafkaTopicInformation.scala
+++ b/spark-atlas-connector/src/main/scala/org/apache/spark/sql/kafka010/atlas/KafkaTopicInformation.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kafka010.atlas
+
+case class KafkaTopicInformation(topicName: String, clusterName: Option[String] = None)
+
+object KafkaTopicInformation {
+  def getQualifiedName(ti: KafkaTopicInformation, defaultClusterName: String): String = {
+    val cName = ti.clusterName.getOrElse(defaultClusterName)
+    s"${ti.topicName}@$cName"
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch introduces SAC specific parameter for Kafka source and sink: `kafka.atlas.cluster.name`. If the option is given for source / sink, SAC uses the value of configuration to atlas cluster name for Kafka topic entity.

## How was this patch tested?

Updated UT passed, Manually tested with Spark 2.4 & Atlas 1.1 with below structured streaming app:

```
val bootstrapServers = "localhost:9092"
val checkpointLocation = "/tmp/mykafka3"
val sourceTopics = Seq("sparksource1hdp30", "sparksource2hdp30").mkString(",")
val sourceTopics2 = Seq("sparksource2hdp30", "sparksource3hdp30").mkString(",")
val targetTopic = "sparksinkhdp30"

val df = spark.readStream.format("kafka").option("kafka.bootstrap.servers", bootstrapServers).option("subscribe", sourceTopics).option("startingOffsets", "earliest").option("kafka.atlas.cluster.name", "source").load()

val df2 = spark.readStream.format("kafka").option("kafka.bootstrap.servers", bootstrapServers).option("subscribe", sourceTopics2).option("startingOffsets", "earliest").load()

df.union(df2).writeStream.format("kafka").option("kafka.bootstrap.servers", bootstrapServers).option("checkpointLocation", checkpointLocation).option("topic", targetTopic).option("kafka.atlas.cluster.name", "sink").start()
```

Five entities created after running query: `sparksource1hdp30@source`, `sparksource2hdp30@source`, `sparksource2hdp30@primary`, `sparksource3hdp30@primary`, `sparksinkhdp30@sink`.