### PR TITLE
[SAC-106][SQL] Disable `atlas.spark.column.enabled` by default

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClientConf.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClientConf.scala
@@ -55,7 +55,7 @@ object AtlasClientConf {
   case class ConfigEntry(key: String, defaultValue: String)
 
   val ATLAS_SPARK_ENABLED = ConfigEntry("atlas.spark.enabled", "true")
-  val ATLAS_SPARK_COLUMN_ENABLED = ConfigEntry("atlas.spark.column.enabled", "true")
+  val ATLAS_SPARK_COLUMN_ENABLED = ConfigEntry("atlas.spark.column.enabled", "false")
 
   val ATLAS_REST_ENDPOINT = ConfigEntry("atlas.rest.address", "localhost:21000")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This configuration is tested on the cluster for both values. This PR aims to change the default value to `false`.

## How was this patch tested?

Pass the Travis CI.

This closes #106 