### PR TITLE
[SAC-108][KAFKA] Remove KafkaHarvester.CONFIG_CUSTOM_CLUSTER_NAME

### DIFF
--- a/spark-atlas-connector/src/main/scala/org/apache/spark/sql/kafka010/atlas/KafkaHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/org/apache/spark/sql/kafka010/atlas/KafkaHarvester.scala
@@ -30,8 +30,6 @@ import org.apache.spark.sql.execution.streaming.sources.MicroBatchWriter
 import scala.collection.mutable
 
 object KafkaHarvester extends AtlasEntityUtils with Logging {
-  val CONFIG_CUSTOM_CLUSTER_NAME: String = "atlas.cluster.name"
-
   override val conf: AtlasClientConf = new AtlasClientConf
 
   def extractTopic(writer: MicroBatchWriter): Option[KafkaTopicInformation] = {
@@ -42,7 +40,7 @@ object KafkaHarvester extends AtlasEntityUtils with Logging {
     // and we can find the way to cache it once we find the cost is not ignorable.
     writer.createWriterFactory() match {
       case KafkaStreamWriterFactory(Some(tp), params, _) =>
-        Some(KafkaTopicInformation(tp, params.get(CONFIG_CUSTOM_CLUSTER_NAME)))
+        Some(KafkaTopicInformation(tp, params.get(AtlasClientConf.CLUSTER_NAME.key)))
       case _ => None
     }
   }
@@ -125,13 +123,13 @@ object KafkaHarvester extends AtlasEntityUtils with Logging {
         e.inputPartition match {
           case e1: KafkaMicroBatchInputPartition =>
             val topic = e1.offsetRange.topicPartition.topic()
-            val customClusterName = e1.executorKafkaParams.get(CONFIG_CUSTOM_CLUSTER_NAME)
+            val customClusterName = e1.executorKafkaParams.get(AtlasClientConf.CLUSTER_NAME.key)
               .asInstanceOf[String]
             topics += KafkaTopicInformation(topic, Option(customClusterName))
 
           case e1: KafkaContinuousInputPartition =>
             val topic = e1.topicPartition.topic()
-            val customClusterName = e1.kafkaParams.get(CONFIG_CUSTOM_CLUSTER_NAME)
+            val customClusterName = e1.kafkaParams.get(AtlasClientConf.CLUSTER_NAME.key)
               .asInstanceOf[String]
             topics += KafkaTopicInformation(topic, Option(customClusterName))
 

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
@@ -97,7 +97,7 @@ class SparkExecutionPlanProcessorForStreamingQuerySuite extends StreamTest {
     val df2 = spark.readStream
       .format("kafka")
       .option("kafka.bootstrap.servers", brokerAddress)
-      .option("kafka." + KafkaHarvester.CONFIG_CUSTOM_CLUSTER_NAME, customClusterName)
+      .option("kafka." + AtlasClientConf.CLUSTER_NAME.key, customClusterName)
       .option("subscribe", topicsToRead2.mkString(","))
       .option("startingOffsets", "earliest")
       .load()
@@ -105,7 +105,7 @@ class SparkExecutionPlanProcessorForStreamingQuerySuite extends StreamTest {
     val query = df.union(df2).writeStream
       .format("kafka")
       .option("kafka.bootstrap.servers", brokerAddress)
-      .option("kafka." + KafkaHarvester.CONFIG_CUSTOM_CLUSTER_NAME, customClusterName)
+      .option("kafka." + AtlasClientConf.CLUSTER_NAME.key, customClusterName)
       .option("topic", topicToWrite)
       .option("checkpointLocation", tempDir.toAbsolutePath.toString)
       .start()

--- a/spark-atlas-connector/src/test/scala/org/apache/spark/sql/kafka010/atlas/KafkaHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/org/apache/spark/sql/kafka010/atlas/KafkaHarvesterSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.kafka010.atlas
 import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicLong
 
+import com.hortonworks.spark.atlas.AtlasClientConf
 import com.hortonworks.spark.atlas.sql.QueryDetail
 import com.hortonworks.spark.atlas.types.external.KAFKA_TOPIC_STRING
 import com.hortonworks.spark.atlas.types.metadata
@@ -78,7 +79,7 @@ class KafkaHarvesterSuite extends StreamTest {
 
     val customAtlasClusterName = "newCluster"
     val newProducerParams = producerParams +
-      (KafkaHarvester.CONFIG_CUSTOM_CLUSTER_NAME -> customAtlasClusterName)
+      (AtlasClientConf.CLUSTER_NAME.key -> customAtlasClusterName)
 
     val writer = new KafkaStreamWriter(topic, newProducerParams, kafkaWriteSchema)
     val microBatchWriter = new MicroBatchWriter(0L, writer)
@@ -229,7 +230,7 @@ class KafkaHarvesterSuite extends StreamTest {
     val df = spark.readStream
       .format("kafka")
       .option("kafka.bootstrap.servers", brokerAddress)
-      .option("kafka." + KafkaHarvester.CONFIG_CUSTOM_CLUSTER_NAME, clusterNameForSources)
+      .option("kafka." + AtlasClientConf.CLUSTER_NAME.key, clusterNameForSources)
       .option("subscribe", topicsToRead.mkString(","))
       .option("startingOffsets", "earliest")
       .load()
@@ -237,7 +238,7 @@ class KafkaHarvesterSuite extends StreamTest {
     val query = df.writeStream
       .format("kafka")
       .option("kafka.bootstrap.servers", brokerAddress)
-      .option("kafka." + KafkaHarvester.CONFIG_CUSTOM_CLUSTER_NAME, clusterNameForSink)
+      .option("kafka." + AtlasClientConf.CLUSTER_NAME.key, clusterNameForSink)
       .option("topic", topicToWrite)
       .option("checkpointLocation", tempDir.toAbsolutePath.toString)
       .start()


### PR DESCRIPTION
## What changes were proposed in this pull request?

We already have `CLUSTER_NAME` in `AtlasClientConf`. This PR removes the duplicated new configuration `KafkaHarvester.CONFIG_CUSTOM_CLUSTER_NAME` and use the existing one instead. This will reduce future confusion.

## How was this patch tested?

Pass the Travis CI.

This closes #108 