### PR TITLE
[SAC-110][SQL] Spark's Hive catalog column name should be lower cases

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -187,7 +187,7 @@ object external {
 
       entity.setAttribute("qualifiedName",
         hiveColumnUniqueAttribute(cluster, db, table, struct.name, isTempTable))
-      entity.setAttribute("name", struct.name)
+      entity.setAttribute("name", struct.name.toLowerCase)
       entity.setAttribute("type", struct.dataType.typeName)
       entity.setAttribute("comment", struct.getComment())
       entity

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -84,8 +84,8 @@ object internal extends Logging {
       val entity = new AtlasEntity(metadata.COLUMN_TYPE_STRING)
 
       entity.setAttribute("qualifiedName",
-        sparkColumnUniqueAttribute(db, table, struct.name))
-      entity.setAttribute("name", struct.name)
+        sparkColumnUniqueAttribute(db, table, struct.name.toLowerCase))
+      entity.setAttribute("name", struct.name.toLowerCase)
       entity.setAttribute("type", struct.dataType.typeName)
       entity.setAttribute("nullable", struct.nullable)
       entity.setAttribute("metadata", struct.metadata.toString())

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessorSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessorSuite.scala
@@ -112,7 +112,7 @@ class SparkCatalogEventProcessorSuite extends FunSuite with Matchers with Before
     SparkUtils.getExternalCatalog().createDatabase(dbDefinition, ignoreIfExists = false)
 
     val tableDefinition =
-      createTable("db1", "tbl1", new StructType().add("id", LongType), CatalogStorageFormat.empty)
+      createTable("db1", "tbl1", new StructType().add("ID", LongType), CatalogStorageFormat.empty)
     val isHiveTbl = processor.isHiveTable(tableDefinition)
     SparkUtils.getExternalCatalog().createTable(tableDefinition, ignoreIfExists = true)
     processor.pushEvent(CreateTableEvent("db1", "tbl1"))
@@ -122,6 +122,7 @@ class SparkCatalogEventProcessorSuite extends FunSuite with Matchers with Before
       assert(atlasClient.createEntityCall(processor.tableType(isHiveTbl)) == 1)
       if (atlasClientConf.get(AtlasClientConf.ATLAS_SPARK_COLUMN_ENABLED).toBoolean) {
         assert(atlasClient.createEntityCall(processor.columnType(isHiveTbl)) == 1)
+        assert("id" === atlasClient.processedEntity.getAttribute("name"))
         assert(atlasClient.createEntityCall(processor.storageFormatType(isHiveTbl)) == 1)
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

To be consistent with Hive, we had better create it in lower cases.

## How was this patch tested?

Manual. This should be tested widh 
```
val ATLAS_SPARK_COLUMN_ENABLED = ConfigEntry("atlas.spark.column.enabled", "false")
```

This closes #110 