### PR TITLE
[SAC-112][SQL] Add `clusterName` to Spark Database entity

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/AtlasEntityUtils.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/AtlasEntityUtils.scala
@@ -43,7 +43,7 @@ trait AtlasEntityUtils {
     if (SparkUtils.isHiveEnabled()) {
       external.hiveDbToEntities(dbDefinition, clusterName, SparkUtils.currUser())
     } else {
-      internal.sparkDbToEntities(dbDefinition, SparkUtils.currUser())
+      internal.sparkDbToEntities(dbDefinition, clusterName, SparkUtils.currUser())
     }
   }
 
@@ -132,7 +132,7 @@ trait AtlasEntityUtils {
     if (isHiveTable(tableDefinition)) {
       external.hiveTableToEntities(tableDefinition, clusterName, mockDbDefinition)
     } else {
-      internal.sparkTableToEntities(tableDefinition, mockDbDefinition)
+      internal.sparkTableToEntities(tableDefinition, clusterName, mockDbDefinition)
     }
   }
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
@@ -18,6 +18,7 @@
 package com.hortonworks.spark.atlas.types
 
 import com.google.common.collect.{ImmutableMap, ImmutableSet}
+import org.apache.atlas.AtlasConstants
 import org.apache.atlas.`type`.AtlasBuiltInTypes.{AtlasBooleanType, AtlasLongType, AtlasStringType}
 import org.apache.atlas.`type`.{AtlasArrayType, AtlasMapType, AtlasTypeUtil}
 import org.apache.atlas.model.typedef.AtlasStructDef.AtlasConstraintDef
@@ -43,6 +44,7 @@ object metadata {
     ImmutableSet.of("DataSet"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
       "qualifiedName", new AtlasStringType),
+    AtlasTypeUtil.createOptionalAttrDef(AtlasConstants.CLUSTER_NAME_ATTRIBUTE, new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("description", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("locationUri", FS_PATH_TYPE_STRING),
     AtlasTypeUtil.createOptionalAttrDef(

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/ml/MLPipelineTrackerIT.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/ml/MLPipelineTrackerIT.scala
@@ -24,12 +24,14 @@ import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 import org.scalatest.Matchers
 
-import com.hortonworks.spark.atlas.{BaseResourceIT, RestAtlasClient, WithHiveSupport}
+import com.hortonworks.spark.atlas.{AtlasClientConf, BaseResourceIT, RestAtlasClient, WithHiveSupport}
 import com.hortonworks.spark.atlas.types._
 import com.hortonworks.spark.atlas.TestUtils._
 
 class MLPipelineTrackerIT extends BaseResourceIT with Matchers with WithHiveSupport {
   private val atlasClient = new RestAtlasClient(atlasClientConf)
+
+  def clusterName: String = atlasClientConf.get(AtlasClientConf.CLUSTER_NAME)
 
   // Return table related entities as a Sequence.
   // The first one is table entity, followed by
@@ -41,7 +43,8 @@ class MLPipelineTrackerIT extends BaseResourceIT with Matchers with WithHiveSupp
       .add("user", StringType, false)
       .add("age", IntegerType, true)
     val tableDefinition = createTable("db1", s"$tableName", schema, sd)
-    val tableEntities = internal.sparkTableToEntities(tableDefinition, Some(dbDefinition))
+    val tableEntities =
+      internal.sparkTableToEntities(tableDefinition, clusterName, Some(dbDefinition))
 
     tableEntities
   }

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/MLAtlasEntityUtilsSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/MLAtlasEntityUtilsSuite.scala
@@ -19,7 +19,7 @@ package com.hortonworks.spark.atlas.types
 
 import java.io.File
 
-import org.apache.atlas.AtlasClient
+import org.apache.atlas.{AtlasClient, AtlasConstants}
 import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.commons.io.FileUtils
 import org.apache.spark.ml.Pipeline
@@ -41,7 +41,8 @@ class MLAtlasEntityUtilsSuite extends FunSuite with Matchers with WithHiveSuppor
       .add("age", IntegerType, true)
     val tableDefinition = createTable("db1", s"$tableName", schema, sd)
 
-    val tableEntities = internal.sparkTableToEntities(tableDefinition, Some(dbDefinition))
+    val tableEntities = internal.sparkTableToEntities(
+      tableDefinition, AtlasConstants.DEFAULT_CLUSTER_NAME, Some(dbDefinition))
     val tableEntity = tableEntities.head
 
     tableEntity

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/SparkAtlasEntityUtilsSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/SparkAtlasEntityUtilsSuite.scala
@@ -19,10 +19,11 @@ package com.hortonworks.spark.atlas.types
 
 import scala.collection.JavaConverters._
 
-import org.apache.atlas.AtlasClient
+import org.apache.atlas.{AtlasClient, AtlasConstants}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
+
 import com.hortonworks.spark.atlas.{AtlasClientConf, TestUtils}
 
 class SparkAtlasEntityUtilsSuite extends FunSuite with Matchers with BeforeAndAfterAll {
@@ -61,6 +62,8 @@ class SparkAtlasEntityUtilsSuite extends FunSuite with Matchers with BeforeAndAf
     val pathEntity = dbEntities.tail.head
     dbEntity.getTypeName should be (metadata.DB_TYPE_STRING)
     dbEntity.getAttribute("name") should be ("db1")
+    dbEntity.getAttribute(AtlasConstants.CLUSTER_NAME_ATTRIBUTE) should be (
+      AtlasConstants.DEFAULT_CLUSTER_NAME)
     dbEntity.getAttribute("locationUri") should be (pathEntity)
     pathEntity.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
       "hdfs:///test/db/db1")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This adds `clusterName` field to Spark's Hive Table model (`metadata.DB_TYPE`) additionally. This information was already shown in `qualifiedName` field, too.

## How was this patch tested?

Pass the Travis CI with the updated test case.
Also, this is verified with Apache Atlas 1.1.0 and Apache Spark 2.4.0.

This closes #112 .
