### PR TITLE
[SAC-114][SQL] Rename attribute `database` to `db` in Spark table model

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -117,7 +117,7 @@ object internal extends Logging {
     tblEntity.setAttribute("qualifiedName",
       sparkTableUniqueAttribute(db, tableDefinition.identifier.table))
     tblEntity.setAttribute("name", tableDefinition.identifier.table)
-    tblEntity.setAttribute("database", dbEntities.head)
+    tblEntity.setAttribute("db", dbEntities.head)
     tblEntity.setAttribute("tableType", tableDefinition.tableType.name)
     tblEntity.setAttribute("storage", sdEntities.head)
     tblEntity.setAttribute("spark_schema", schemaEntities.asJava)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
@@ -96,7 +96,7 @@ object metadata {
     ImmutableSet.of("DataSet"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
       "qualifiedName", new AtlasStringType),
-    AtlasTypeUtil.createOptionalAttrDef("database", DB_TYPE_STRING),
+    AtlasTypeUtil.createOptionalAttrDef("db", DB_TYPE_STRING),
     AtlasTypeUtil.createOptionalAttrDef("tableType", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDefWithConstraint(
       "storage", STORAGEDESC_TYPE_STRING, AtlasConstraintDef.CONSTRAINT_TYPE_OWNED_REF, null),

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForBatchQuerySuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForBatchQuerySuite.scala
@@ -80,7 +80,7 @@ class SparkExecutionPlanProcessorForBatchQuerySuite extends StreamTest {
     assert(getStringAttribute(databaseEntity, "qualifiedName") === databaseQualifiedName)
 
     // database entity in table entity should be same as outer database entity
-    val databaseEntityInTable = getAtlasEntityAttribute(tableEntity, "database")
+    val databaseEntityInTable = getAtlasEntityAttribute(tableEntity, "db")
     assert(databaseEntity === databaseEntityInTable)
 
     val databaseLocationFsEntity = getAtlasEntityAttribute(databaseEntity, "locationUri")

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/SparkAtlasEntityUtilsSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/SparkAtlasEntityUtilsSuite.scala
@@ -126,7 +126,7 @@ class SparkAtlasEntityUtilsSuite extends FunSuite with Matchers with BeforeAndAf
 
     tableEntity.getTypeName should be (metadata.TABLE_TYPE_STRING)
     tableEntity.getAttribute("name") should be ("tbl1")
-    tableEntity.getAttribute("database") should be (dbEntity)
+    tableEntity.getAttribute("db") should be (dbEntity)
     tableEntity.getAttribute("storage") should be (sdEntity)
     tableEntity.getAttribute("spark_schema") should be (schemaEntities.asJava)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR renames attribute `database` to `db` in Spark table model. This is the consistent name with Hive and work like the following.

![screen](https://user-images.githubusercontent.com/9700541/48653828-cac79100-e9bc-11e8-934a-52718a17f992.png)

## How was this patch tested?

Pass the Travis CI with the updated test case.
Also, this is verified manually with Apache Spark 1.1.0 and Apache Spark 2.4.0.

This closes #114 .
