### PR TITLE
[SAC-116][SQL] Add 'ownerType' to Spark Table entity

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -136,6 +136,7 @@ object external {
     dbEntity.setAttribute("location", dbDefinition.locationUri.toString)
     dbEntity.setAttribute("parameters", dbDefinition.properties.asJava)
     dbEntity.setAttribute("owner", owner)
+    dbEntity.setAttribute("ownerType", "USER")
     Seq(dbEntity)
   }
 
@@ -232,6 +233,7 @@ object external {
       hiveTableUniqueAttribute(cluster, db, table /* , isTemporary = false */))
     tblEntity.setAttribute("name", table)
     tblEntity.setAttribute("owner", tableDefinition.owner)
+    tblEntity.setAttribute("ownerType", "USER")
     tblEntity.setAttribute("createTime", new Date(tableDefinition.createTime))
     tblEntity.setAttribute("lastAccessTime", new Date(tableDefinition.lastAccessTime))
     tableDefinition.comment.foreach(tblEntity.setAttribute("comment", _))

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -48,6 +48,7 @@ object internal extends Logging {
     dbEntity.setAttribute("locationUri", pathEntity)
     dbEntity.setAttribute("properties", dbDefinition.properties.asJava)
     dbEntity.setAttribute("owner", owner)
+    dbEntity.setAttribute("ownerType", "USER")
     Seq(dbEntity, pathEntity)
   }
 
@@ -126,6 +127,7 @@ object internal extends Logging {
     tableDefinition.bucketSpec.foreach(
       b => tblEntity.setAttribute("bucketSpec", b.toLinkedHashMap.asJava))
     tblEntity.setAttribute("owner", tableDefinition.owner)
+    tblEntity.setAttribute("ownerType", "USER")
     tblEntity.setAttribute("createTime", tableDefinition.createTime)
     tblEntity.setAttribute("lastAccessTime", tableDefinition.lastAccessTime)
     tblEntity.setAttribute("properties", tableDefinition.properties.asJava)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
@@ -110,6 +110,7 @@ object metadata {
     AtlasTypeUtil.createOptionalAttrDef(
       "bucketSpec", new AtlasMapType(new AtlasStringType, new AtlasStringType)),
     AtlasTypeUtil.createOptionalAttrDef("owner", new AtlasStringType),
+    AtlasTypeUtil.createOptionalAttrDef("ownerType", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("createTime", new AtlasLongType),
     AtlasTypeUtil.createOptionalAttrDef("lastAccessTime", new AtlasLongType),
     AtlasTypeUtil.createOptionalAttrDef(

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/TestUtils.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/TestUtils.scala
@@ -23,6 +23,8 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogStorageFormat, CatalogTable, CatalogTableType}
 import org.apache.spark.sql.types.StructType
 
+import com.hortonworks.spark.atlas.utils.SparkUtils
+
 object TestUtils {
   def createDB(name: String, location: String): CatalogDatabase = {
     CatalogDatabase(name, "", new URI(location), Map.empty)
@@ -49,6 +51,8 @@ object TestUtils {
       CatalogTableType.MANAGED,
       storage,
       schema,
-      provider = if (isHiveTable) Some("hive") else None)
+      provider = if (isHiveTable) Some("hive") else None,
+      bucketSpec = None,
+      owner = SparkUtils.currUser())
   }
 }

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CatalogEventToAtlasIT.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CatalogEventToAtlasIT.scala
@@ -67,6 +67,7 @@ class CatalogEventToAtlasIT extends BaseResourceIT with Matchers {
       entity should not be (null)
       entity.getAttribute("name") should be ("db1")
       entity.getAttribute("owner") should be (SparkUtils.currUser())
+      entity.getAttribute("ownerType") should be ("USER")
     }
 
     // Drop DB from external catalog to make sure we also delete the corresponding Atlas entity

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/SparkAtlasEntityUtilsSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/SparkAtlasEntityUtilsSuite.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.types._
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
 
 import com.hortonworks.spark.atlas.{AtlasClientConf, TestUtils}
+import com.hortonworks.spark.atlas.utils.SparkUtils
 
 class SparkAtlasEntityUtilsSuite extends FunSuite with Matchers with BeforeAndAfterAll {
   import TestUtils._
@@ -127,6 +128,8 @@ class SparkAtlasEntityUtilsSuite extends FunSuite with Matchers with BeforeAndAf
     tableEntity.getTypeName should be (metadata.TABLE_TYPE_STRING)
     tableEntity.getAttribute("name") should be ("tbl1")
     tableEntity.getAttribute("db") should be (dbEntity)
+    tableEntity.getAttribute("owner") should be (SparkUtils.currUser())
+    tableEntity.getAttribute("ownerType") should be ("USER")
     tableEntity.getAttribute("storage") should be (sdEntity)
     tableEntity.getAttribute("spark_schema") should be (schemaEntities.asJava)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds 'ownerType' attribute to Spark Table entity.

![ownertype](https://user-images.githubusercontent.com/9700541/48654381-2ac03680-e9c1-11e8-980d-c5beeee82219.png)

## How was this patch tested?

Pass the Travis CI with the updated test case.
This is also tested with Apache Atlas 1.1.0 and Apache Spark 2.4.0.

This closes #116 .
