### PR TITLE
[SAC-118][SQL] CTAS should not warn `Missing unknown leaf node`

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -145,6 +145,8 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
           case r if r.getClass.getCanonicalName.endsWith(HBASE_RELATION_CLASS_NAME) =>
             getHBaseEntity(r)
         }
+        case _: OneRowRelation =>
+          Seq.empty
         case e =>
           logWarn(s"Missing unknown leaf node: $e")
           Seq.empty


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR add a logic to handle `OneRowRelation`.
```scala
scala> sql("create table ctas1 as select 1 a")
... WARN  CommandsHarvester$:44 - Missing unknown leaf node: OneRowRelation
```

## How was this patch tested?

This should be tested manually since this removes only WARN message.

This closes #118 