### PR TITLE
[SAC-124][SQL] Hive Warehouse Connector support

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClient.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClient.scala
@@ -33,6 +33,8 @@ trait AtlasClient extends Logging {
 
   def updateAtlasTypeDefs(typeDefs: AtlasTypesDef): Unit
 
+  def findEntity(typeNang: String, qualifiedName: String): AtlasEntity
+
   final def createEntities(entities: Seq[AtlasEntity]): Unit = {
     if (entities.isEmpty) {
       return
@@ -80,6 +82,11 @@ trait AtlasClient extends Logging {
 
 object AtlasClient {
   @volatile private var client: AtlasClient = null
+
+  protected[atlas] def atlasClient(): AtlasClient = {
+    assert(client != null, "atlasClient(conf) should be called first.")
+    client
+  }
 
   def atlasClient(conf: AtlasClientConf): AtlasClient = {
     if (client == null) {

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/KafkaAtlasClient.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/KafkaAtlasClient.scala
@@ -48,6 +48,10 @@ class KafkaAtlasClient(atlasClientConf: AtlasClientConf) extends AtlasHook with 
     throw new UnsupportedOperationException("Kafka atlas client doesn't support update type defs")
   }
 
+  override def findEntity(typeName: String, qualifiedName: String): AtlasEntity = {
+    throw new UnsupportedOperationException("Kafka atlas client doesn't support find entities")
+  }
+
   override protected def doCreateEntities(entities: Seq[AtlasEntity]): Unit = {
     val createRequests = entities.map { e =>
       new EntityCreateRequest(

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/RestAtlasClient.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/RestAtlasClient.scala
@@ -62,6 +62,10 @@ class RestAtlasClient(atlasClientConf: AtlasClientConf) extends AtlasClient {
     client.updateAtlasTypeDefs(typeDefs)
   }
 
+  override def findEntity(typeName: String, qualifiedName: String): AtlasEntity = {
+    client.getEntityByAttribute(typeName, Map("qualifiedName" -> qualifiedName).asJava).getEntity
+  }
+
   override protected def doCreateEntities(entities: Seq[AtlasEntity]): Unit = {
     val entitesWithExtInfo = new AtlasEntitiesWithExtInfo()
     entities.foreach(entitesWithExtInfo.addEntity)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.execution.command.{CreateDataSourceTableAsSelectComm
 import org.apache.spark.sql.execution.datasources.{InsertIntoHadoopFsRelationCommand, LogicalRelation, SaveIntoDataSourceCommand}
 import org.apache.spark.sql.hive.execution._
 import org.apache.spark.sql.sources.BaseRelation
-import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec
+import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanExec, WriteToDataSourceV2Exec}
 import org.apache.spark.sql.sources.v2.writer.DataSourceWriter
 
 import com.hortonworks.spark.atlas.AtlasClientConf
@@ -428,8 +428,6 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
   }
 
   object HWCEntities extends Logging {
-    import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanExec}
-
     private def maybeClass(name: String): Option[Class[_]] = try {
       Some(Class.forName(name))
     } catch {

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -459,7 +459,6 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
 
     def getHWCEntity(options: Map[String, String]): Seq[AtlasEntity] = {
       if (batchReadSourceClass.isDefined) {
-
         val (db, tableName) = getDbTableNames(
           options.getOrElse("default.db", "default"), options.getOrElse("table", ""))
         external.hwcTableToEntities(db, tableName, clusterName)
@@ -519,7 +518,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
     }
 
     // This logic was ported from HWC's `SchemaUtil.getDbTableNames`
-    private def getDbTableNames(db: String, nameStr: String): Tuple2[String, String] = {
+    private def getDbTableNames(db: String, nameStr: String): (String, String) = {
       val nameParts = nameStr.split("\\.")
       if (nameParts.length == 1) {
         // hive.table(<unqualified_tableName>) so fill in db from default session db

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -21,17 +21,19 @@ import org.json4s.JsonAST.JObject
 import org.json4s.jackson.JsonMethods._
 
 import scala.util.Try
-import org.apache.atlas.model.instance.AtlasEntity
 
+import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.execution.{FileRelation, FileSourceScanExec}
+import org.apache.spark.sql.execution.{FileRelation, FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.command.{CreateDataSourceTableAsSelectCommand, CreateViewCommand, LoadDataCommand}
 import org.apache.spark.sql.execution.datasources.{InsertIntoHadoopFsRelationCommand, LogicalRelation, SaveIntoDataSourceCommand}
 import org.apache.spark.sql.hive.execution._
 import org.apache.spark.sql.sources.BaseRelation
+import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec
+import org.apache.spark.sql.sources.v2.writer.DataSourceWriter
 
 import com.hortonworks.spark.atlas.AtlasClientConf
 import com.hortonworks.spark.atlas.types.{AtlasEntityUtils, external, internal}
@@ -61,6 +63,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
         case r: HiveTableRelation => tableToEntities(r.tableMeta)
         case v: View => tableToEntities(v.desc)
         case l: LogicalRelation => tableToEntities(l.catalogTable.get)
+        case HWCEntities(hwcEntities) => hwcEntities
         case e =>
           logWarn(s"Missing unknown leaf node: $e")
           Seq.empty
@@ -101,6 +104,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
             case r: FileRelation => r.inputFiles.map(external.pathToEntity).toSeq
             case _ => Seq.empty
           }
+        case HWCEntities(hwcEntities) => hwcEntities
         case local: LocalRelation =>
           logInfo("Local Relation to store Spark ML pipelineModel")
           Seq.empty
@@ -147,6 +151,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
         }
         case _: OneRowRelation =>
           Seq.empty
+        case HWCEntities(hwcEntities) => hwcEntities
         case e =>
           logWarn(s"Missing unknown leaf node: $e")
           Seq.empty
@@ -186,6 +191,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
           l.catalogTable.map(tableToEntities(_)).getOrElse {
             l.relation.asInstanceOf[FileRelation].inputFiles.map(external.pathToEntity).toSeq
           }
+        case HWCEntities(hwcEntities) => hwcEntities
         case e =>
           logWarn(s"Missing unknown leaf node: $e")
           Seq.empty
@@ -246,6 +252,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
         case f: FileSourceScanExec =>
           f.tableIdentifier.map(prepareEntities).getOrElse(
             f.relation.location.inputFiles.map(external.pathToEntity).toSeq)
+        case HWCEntities(hwcEntities) => hwcEntities
         case e =>
           logWarn(s"Missing unknown leaf node: $e")
           Seq.empty
@@ -310,6 +317,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
             l.relation.asInstanceOf[FileRelation].inputFiles.map(external.pathToEntity).toSeq)
           case e => Seq.empty
         }
+        case HWCEntities(hwcEntities) => hwcEntities
         case e =>
           logWarn(s"Missing unknown leaf node: $e")
           Seq.empty
@@ -376,5 +384,156 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       "executionTime" -> qd.executionTime.toString,
       "details" -> qd.qe.toString(),
       "sparkPlanDescription" -> qd.qe.sparkPlan.toString())
+  }
+
+  object HWCHarvester extends Harvester[WriteToDataSourceV2Exec] {
+    override def harvest(node: WriteToDataSourceV2Exec, qd: QueryDetail): Seq[AtlasEntity] = {
+      // Source table entity
+      val inputsEntities = qd.qe.sparkPlan.collectLeaves().map {
+        case h if h.getClass.getName == "org.apache.spark.sql.hive.execution.HiveTableScanExec" =>
+          Try {
+            val method = h.getClass.getMethod("relation")
+            method.setAccessible(true)
+            val relation = method.invoke(h).asInstanceOf[HiveTableRelation]
+            tableToEntities(relation.tableMeta)
+          }.getOrElse(Seq.empty)
+
+        case f: FileSourceScanExec =>
+          f.tableIdentifier.map(prepareEntities).getOrElse(
+            f.relation.location.inputFiles.map(external.pathToEntity).toSeq)
+        case HWCEntities(hwcEntities) => hwcEntities
+        case e =>
+          logWarn(s"Missing unknown leaf node: $e")
+          Seq.empty
+      }
+
+      // Supports Spark HWC (destination table entity)
+      val outputEntities = HWCEntities.getHWCEntity(node.writer)
+
+      // Creates process entity
+      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
+      val outputTableEntities = outputEntities.toList
+      val logMap = getPlanInfo(qd)
+
+      // ML related cached object
+      if (internal.cachedObjects.contains("model_uid")) {
+        internal.updateMLProcessToEntity(inputTablesEntities, outputTableEntities, logMap)
+      } else {
+        // Creates process entity
+        val pEntity = internal.etlProcessToEntity(
+          inputTablesEntities, outputTableEntities, logMap)
+        Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
+      }
+    }
+  }
+
+  object HWCEntities extends Logging {
+    import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanExec}
+
+    private def maybeClass(name: String): Option[Class[_]] = try {
+      Some(Class.forName(name))
+    } catch {
+      case _: ClassNotFoundException => None
+    }
+
+    private val batchReadSourceClass: Option[Class[_]] =
+      maybeClass(HWCSupport.BATCH_READ_SOURCE)
+
+    private val batchWriteClass: Option[Class[_]] = maybeClass(HWCSupport.BATCH_WRITE)
+    private val batchStreamWriteClass: Option[Class[_]] =
+      maybeClass(HWCSupport.BATCH_STREAM_WRITE)
+
+    private val streamWriteClass: Option[Class[_]] = maybeClass(HWCSupport.STREAM_WRITE)
+
+    def unapply(plan: LogicalPlan): Option[Seq[AtlasEntity]] = plan match {
+      case ds: DataSourceV2Relation
+          if ds.source.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_READ_SOURCE) =>
+        Some(getHWCEntity(ds.options))
+      case _ => None
+    }
+
+    def unapply(plan: SparkPlan): Option[Seq[AtlasEntity]] = plan match {
+      case ds: DataSourceV2ScanExec
+          if ds.source.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_READ_SOURCE) =>
+        Some(getHWCEntity(ds.options))
+      case _ => None
+    }
+
+    def getHWCEntity(options: Map[String, String]): Seq[AtlasEntity] = {
+      if (batchReadSourceClass.isDefined) {
+
+        val (db, tableName) = getDbTableNames(
+          options.getOrElse("default.db", "default"), options.getOrElse("table", ""))
+        external.hwcTableToEntities(db, tableName, clusterName)
+      } else {
+        logWarn(s"Class ${HWCSupport.BATCH_READ_SOURCE} is not found")
+        Seq.empty
+      }
+    }
+
+    def getHWCEntity(r: DataSourceWriter): Seq[AtlasEntity] = r match {
+      case _ if r.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_WRITE) =>
+        if (batchWriteClass.isDefined) {
+          val f = r.getClass.getDeclaredField("options")
+          f.setAccessible(true)
+          val options = f.get(r).asInstanceOf[java.util.Map[String, String]]
+          val (db, tableName) = getDbTableNames(
+            options.getOrDefault("default.db", "default"), options.getOrDefault("table", ""))
+          external.hwcTableToEntities(db, tableName, clusterName)
+        } else {
+          logWarn(s"Class ${HWCSupport.BATCH_WRITE} is not found")
+          Seq.empty
+        }
+
+      case _ if r.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_STREAM_WRITE) =>
+        if (batchStreamWriteClass.isDefined) {
+          val dbField = r.getClass.getDeclaredField("db")
+          dbField.setAccessible(true)
+          val db = dbField.get(r).asInstanceOf[String]
+
+          val tableField = r.getClass.getDeclaredField("table")
+          tableField.setAccessible(true)
+          val table = tableField.get(r).asInstanceOf[String]
+
+          external.hwcTableToEntities(db, table, clusterName)
+        } else {
+          logWarn(s"Class ${HWCSupport.BATCH_WRITE} is not found")
+          Seq.empty
+        }
+
+      case _ if r.getClass.getCanonicalName.endsWith(HWCSupport.STREAM_WRITE) =>
+        if (streamWriteClass.isDefined) {
+          val dbField = r.getClass.getDeclaredField("db")
+          dbField.setAccessible(true)
+          val db = dbField.get(r).asInstanceOf[String]
+
+          val tableField = r.getClass.getDeclaredField("table")
+          tableField.setAccessible(true)
+          val table = tableField.get(r).asInstanceOf[String]
+
+          external.hwcTableToEntities(db, table, clusterName)
+        } else {
+          logWarn(s"Class ${HWCSupport.STREAM_WRITE} is not found")
+          Seq.empty
+        }
+
+      case _ => Seq.empty
+    }
+
+    // This logic was ported from HWC's `SchemaUtil.getDbTableNames`
+    private def getDbTableNames(db: String, nameStr: String): Tuple2[String, String] = {
+      val nameParts = nameStr.split("\\.")
+      if (nameParts.length == 1) {
+        // hive.table(<unqualified_tableName>) so fill in db from default session db
+        (db, nameStr)
+      }
+      else if (nameParts.length == 2) {
+        // hive.table(<qualified_tableName>) so use the provided db
+        (nameParts(0), nameParts(1))
+      } else {
+        throw new IllegalArgumentException(
+          "Table name should be specified as either <table> or <db.table>")
+      }
+    }
   }
 }

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/HWCStreamingHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/HWCStreamingHarvester.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql
+
+import com.hortonworks.spark.atlas.sql.CommandsHarvester.HWCEntities
+import org.apache.atlas.model.instance.AtlasEntity
+import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec
+import org.apache.spark.sql.kafka010.atlas.KafkaHarvester
+
+
+object HWCStreamingHarvester extends Harvester[WriteToDataSourceV2Exec] {
+  override def harvest(node: WriteToDataSourceV2Exec, qd: QueryDetail): Seq[AtlasEntity] = {
+    // source topics - can be multiple topics
+    val sourceTopics = KafkaHarvester.extractSourceTopics(node)
+    val inputsEntities: Seq[AtlasEntity] = KafkaHarvester.extractInputEntities(sourceTopics)
+
+    val outputEntities = HWCEntities.getHWCEntity(node.writer)
+    val logMap = KafkaHarvester.makeLogMap(sourceTopics, None, qd)
+
+    val updatedLogMap = logMap ++ Map(
+      "sparkPlanDescription" ->
+      s"${logMap.get("sparkPlanDescription")}\n${qd.qe.sparkPlan.toString()}")
+
+    KafkaHarvester.makeProcessEntities(inputsEntities, outputEntities, updatedLogMap)
+  }
+}

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
@@ -140,6 +140,29 @@ class SparkExecutionPlanProcessor(
 
 }
 
+/**
+ * Extracts Atlas entities related with Hive Warehouse Connector plans.
+ *
+ * Hive Warehouse Connector currently supports four types of operations:
+ *   1. SQL / DataFrame Read (batch read)
+ *   2. SQL / DataFrame Write (batch write)
+ *   3. SQL / DataFrame Write in streaming manner (batch write in streaming)
+ *   4. Structured Streaming Write (streaming write)
+ *
+ * For 1., it is supported by looking logical plans (if available) or physical
+ * plans up at `HWCEntities` for every execution plan being processed above
+ * when it's possible.
+ *
+ * For 2. and 3., it checks only when the execution plan is `WriteToDataSourceV2Exec`.
+ * It checks the write implementation of DataSourceV2 is HWC or not and dispatches to harvest
+ * appropriate entities.
+ *
+ * For 4., it is same as 2. and 3. but it reuses Kafka harvester to handle input sources
+ * under the hood when it dispatches to harvest.
+ *
+ * See also HCC article, "Integrating Apache Hive with Apache Spark - Hive Warehouse Connector"
+ * https://goo.gl/p3EXhz
+ */
 object HWCSupport {
   val BATCH_READ_SOURCE =
     "com.hortonworks.spark.sql.hive.llap.HiveWarehouseConnector"

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -264,6 +264,8 @@ object external {
       db: String,
       table: String,
       cluster: String): Seq[AtlasEntity] = {
+    // For HWC tables, we're not going to create new Hive table entities within Spark side.
+    // Therefore, it finds the existing Hive table entities.
     val entity = AtlasClient.atlasClient().findEntity(
       HWC_TABLE_TYPE_STRING, hwcTableUniqueAttribute(cluster, db, table))
     Option(entity).toSeq

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessorSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessorSuite.scala
@@ -163,6 +163,8 @@ class FirehoseAtlasClient(conf: AtlasClientConf) extends AtlasClient {
     new AtlasTypesDef()
   }
 
+  override def findEntity(typeNang: String, qualifiedName: String): AtlasEntity = { null }
+
   override protected def doCreateEntities(entities: Seq[AtlasEntity]): Unit = {
     entities.foreach { e =>
       createEntityCall(e.getTypeName) =
@@ -184,5 +186,6 @@ class FirehoseAtlasClient(conf: AtlasClientConf) extends AtlasClient {
       attribute: String): Unit = {
     deleteEntityCall(entityType) = deleteEntityCall.getOrElse(entityType, 0) + 1
   }
+
 }
 

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/CreateEntitiesTrackingAtlasClient.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/CreateEntitiesTrackingAtlasClient.scala
@@ -44,4 +44,6 @@ class CreateEntitiesTrackingAtlasClient extends AtlasClient {
 
   override protected def doUpdateEntityWithUniqueAttr(entityType: String, attribute: String,
                                                       entity: AtlasEntity): Unit = {}
+
+  override def findEntity(typeNang: String, qualifiedName: String): AtlasEntity = { null }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to add HWC support in SAC.

Hive Warehouse Connector currently supports four types of operations:
  1. SQL / DataFrame Read (batch read)
  2. SQL / DataFrame Write (batch write)
  3. SQL / DataFrame Write in streaming manner (batch write in streaming)
  4. Structured Streaming Write (streaming write)

For 1., it is supported by looking logical plans (if available) or physical
plans up at `HWCEntities` for every execution plan being processed above
when it's possible.

For 2. and 3., it checks only when the execution plan is `WriteToDataSourceV2Exec`.
It checks the write implementation of DataSourceV2 is HWC or not and dispatches to harvest
appropriate entities.

For 4., it is same as 2. and 3. but it reuses Kafka harvester to handle input sources
under the hood when it dispatches to harvest.

## How was this patch tested?

Manually tested:

![screen shot 2018-11-20 at 4 56 49 pm](https://user-images.githubusercontent.com/6477701/48814851-65d2b900-ed77-11e8-8a43-a9f50cd58443.png)

The examples at https://community.hortonworks.com/content/kbentry/223626/integrating-apache-hive-with-apache-spark-hive-war.html were used and tested.

Closes #124