### PR TITLE
[SAC-128][SQL] Cyclic `INSERT INTO` should not generate outbound link

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -80,9 +80,11 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
         internal.updateMLProcessToEntity(inputTablesEntities, outputEntities, logMap)
       } else {
         // create process entity
+        // Atlas doesn't support cycle here.
+        val cleanedOutput = cleanOutput(inputTablesEntities, outputTableEntities)
         val pEntity = internal.etlProcessToEntity(
-          inputTablesEntities, outputTableEntities, logMap)
-        Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
+          inputTablesEntities, cleanedOutput, logMap)
+        Seq(pEntity) ++ inputsEntities.flatten ++ cleanedOutput
       }
     }
   }
@@ -125,9 +127,10 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       if (internal.cachedObjects.contains("model_uid")) {
         internal.updateMLProcessToEntity(inputTablesEntities, outputEntities, logMap)
       } else {
+        val cleanedOutput = cleanOutput(inputTablesEntities, outputEntities)
         val processEntity = internal.etlProcessToEntity(
-          inputTablesEntities, List(outputEntities.head), logMap)
-          Seq(processEntity) ++ inputsEntities.flatten ++ outputEntities
+          inputTablesEntities, cleanedOutput.headOption.toList, logMap)
+          Seq(processEntity) ++ inputsEntities.flatten ++ cleanedOutput
         }
     }
   }

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/AtlasEntityUtils.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/AtlasEntityUtils.scala
@@ -161,4 +161,15 @@ trait AtlasEntityUtils {
 
   def processUniqueAttribute(executionId: Long): String =
     internal.sparkProcessUniqueAttribute(executionId)
+
+  // If there is cycle, return empty output entity list
+  def cleanOutput(inputs: Seq[AtlasEntity], outputs: Seq[AtlasEntity]): List[AtlasEntity] = {
+    val qualifiedNames = inputs.map(e => e.getAttribute("qualifiedName"))
+    val isCycle = outputs.exists(x => qualifiedNames.contains(x.getAttribute("qualifiedName")))
+    if (isCycle) {
+      List.empty
+    } else {
+      outputs.toList
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Atlas doesn't support cycle. Currently, Spark fails like the following. Hive omits the out-going edge to avoid this situation.

```scala
scala> sql("insert into t select * from t")
18/11/20 19:18:24 WARN RestAtlasClient: Failed to create entities
java.lang.IllegalStateException: Fail to get create entities
        at com.hortonworks.spark.atlas.RestAtlasClient.doCreateEntities(RestAtlasClient.scala:73)
```

**AFTER**

![cycle](https://user-images.githubusercontent.com/9700541/48873766-954bea80-eda4-11e8-8ff6-0fbb23fa6d45.png)


## How was this patch tested?

- Pass the Travis CI with newly added test cases.
- Also, this is verified with Apache Atlas 1.1.0 and Apache Spark 2.4.0.