### PR TITLE
[SAC-131][SQL] Rename attribute `storage` to `sd` in Spark table model

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
@@ -69,7 +69,7 @@ object metadata {
       "table",
       TABLE_TYPE_STRING,
       AtlasConstraintDef.CONSTRAINT_TYPE_INVERSE_REF,
-      ImmutableMap.of(AtlasConstraintDef.CONSTRAINT_PARAM_ATTRIBUTE, "storage")))
+      ImmutableMap.of(AtlasConstraintDef.CONSTRAINT_PARAM_ATTRIBUTE, "sd")))
 
   // ========= Column type =========
   val COLUMN_TYPE = AtlasTypeUtil.createClassTypeDef(
@@ -99,7 +99,7 @@ object metadata {
     AtlasTypeUtil.createOptionalAttrDef("db", DB_TYPE_STRING),
     AtlasTypeUtil.createOptionalAttrDef("tableType", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDefWithConstraint(
-      "storage", STORAGEDESC_TYPE_STRING, AtlasConstraintDef.CONSTRAINT_TYPE_OWNED_REF, null),
+      "sd", STORAGEDESC_TYPE_STRING, AtlasConstraintDef.CONSTRAINT_TYPE_OWNED_REF, null),
     AtlasTypeUtil.createOptionalAttrDefWithConstraint(
       "spark_schema",
       "array<spark_column>",


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to rename `storage` to `sd` in Spark table model to be consistent with Hive. Also, this will recover the missing link in the current `master` branch like the following.

![sd](https://user-images.githubusercontent.com/9700541/48876193-b2d38100-edb1-11e8-80ff-88e8ac3a18ce.png)


## How was this patch tested?

This closes #131 
