### PR TITLE
[SAC-133][SQL] CREATE VIEW should support OneRowRelation

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessor.scala
@@ -77,7 +77,13 @@ class SparkCatalogEventProcessor(
         } else {
           // We should handle both cases. The type values will be changed later.
           val excludedTypes = Seq(external.HIVE_COLUMN_TYPE_STRING, metadata.COLUMN_TYPE_STRING)
-          val cleanedEntities = tableEntities.filterNot(e => excludedTypes.contains(e.getTypeName))
+          val cleanedEntities = tableEntities
+            .filterNot(e => excludedTypes.contains(e.getTypeName))
+            .map { e =>
+              e.removeAttribute("columns")
+              e.removeAttribute("spark_schema")
+              e
+            }
           atlasClient.createEntities(cleanedEntities)
           logDebug(s"Created table entity $table without columns")
         }

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
@@ -17,6 +17,8 @@
 
 package com.hortonworks.spark.atlas.sql
 
+import scala.collection.convert.Wrappers.SeqWrapper
+
 import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.command._
@@ -148,6 +150,14 @@ class SparkExecutionPlanProcessor(
           .map {
             case e if dbTypes.contains(e.getTypeName) =>
               e.removeAttribute("columns")
+              e
+            case e if e.getTypeName.equals(metadata.PROCESS_TYPE_STRING) =>
+              Seq(e.getAttribute("inputs"), e.getAttribute("outputs")).foreach { list =>
+                list.asInstanceOf[SeqWrapper[AtlasEntity]].underlying.foreach { o =>
+                  o.removeAttribute("columns")
+                  o.removeAttribute("spark_schema")
+                }
+              }
               e
             case e => e
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to handle `OneRowRelation` and remove nested column information.
```scala
scala> sql("create view v1 as select 1")
WARN SparkExecutionPlanProcessor: Caught exception during parsing event
java.lang.ClassCastException: org.apache.spark.sql.catalyst.plans.logical.OneRowRelation cannot be cast to org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
```

## How was this patch tested?

Pass the Travis CI.