### PR TITLE
[SAC-135] Change default client to Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Also make sure atlas configuration file `atlas-application.properties` is in the
 
 If you're using cluster mode, please also ship this conf file to the remote Drive using `--files atlas-application.properties`.
 
+Spark Atlas Connector supports two types of Atlas clients, "kafka" and "rest". You can configure which type of client via setting `atlas.client.type` to whether `kafka` or `rest`.
+The default value is `kafka` which provides stable and secured way of publishing changes. Atlas has embedded Kafka instance so you can test it out in test environment, but it's encouraged to use external kafka cluster in production. If you don't have Kafka cluster in production, you may want to set client to `rest`.
+
 To Use it in Secure Environment
 ===
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClientConf.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClientConf.scala
@@ -62,7 +62,7 @@ object AtlasClientConf {
   val BLOCKING_QUEUE_CAPACITY = ConfigEntry("atlas.blockQueue.size", "10000")
   val BLOCKING_QUEUE_PUT_TIMEOUT = ConfigEntry("atlas.blockQueue.putTimeout.ms", "3000")
 
-  val CLIENT_TYPE = ConfigEntry("atlas.client.type", "rest")
+  val CLIENT_TYPE = ConfigEntry("atlas.client.type", "kafka")
   val CLIENT_USERNAME = ConfigEntry("atlas.client.username", "admin")
   val CLIENT_PASSWORD = ConfigEntry("atlas.client.password", "admin123")
   val CLIENT_NUM_RETRIES = ConfigEntry("atlas.client.numRetries", "3")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch changes the default client to Kafka which provides better stability and security. Rest API client is still supported via setting `atlas.client.type` to `rest`.

## How was this patch tested?

Manually tested (Spark 2.4, Atlas 1.1 with embedded HBase, Solr, Kafka)

This closes #135 