### PR TITLE
[SAC-137] Use API V2 for Kafka Client (AtlasHook)

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/KafkaAtlasClient.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/KafkaAtlasClient.scala
@@ -23,12 +23,15 @@ import scala.collection.JavaConverters._
 import com.sun.jersey.core.util.MultivaluedMapImpl
 import org.apache.atlas.hook.AtlasHook
 import org.apache.atlas.model.typedef.AtlasTypesDef
-import org.apache.atlas.model.instance.AtlasEntity
+import org.apache.atlas.model.instance.{AtlasEntity, AtlasObjectId}
 import org.apache.atlas.v1.model.notification.HookNotificationV1
 import org.apache.atlas.v1.model.notification.HookNotificationV1.{EntityCreateRequest, EntityDeleteRequest}
 import org.apache.atlas.v1.model.instance.Referenceable
 import org.apache.atlas.model.notification.HookNotification
 import com.hortonworks.spark.atlas.utils.SparkUtils
+import org.apache.atlas.AtlasClientV2.API_V2
+import org.apache.atlas.model.instance.AtlasEntity.{AtlasEntitiesWithExtInfo, AtlasEntityWithExtInfo}
+import org.apache.atlas.model.notification.HookNotification.{EntityCreateRequestV2, EntityDeleteRequestV2, EntityPartialUpdateRequestV2}
 
 class KafkaAtlasClient(atlasClientConf: AtlasClientConf) extends AtlasHook with AtlasClient {
 
@@ -53,62 +56,39 @@ class KafkaAtlasClient(atlasClientConf: AtlasClientConf) extends AtlasHook with 
   }
 
   override protected def doCreateEntities(entities: Seq[AtlasEntity]): Unit = {
-    val createRequests = entities.map { e =>
-      new EntityCreateRequest(
-        SparkUtils.currUser(), entityToReferenceable(e)): HookNotification
-    }.toList.asJava
+    val entitiesWithExtInfo = new AtlasEntitiesWithExtInfo()
+    entities.foreach(entitiesWithExtInfo.addEntity)
+    val createRequest = new EntityCreateRequestV2(
+      SparkUtils.currUser(), entitiesWithExtInfo): HookNotification
 
-    notifyEntities(createRequests, SparkUtils.ugi())
+    notifyEntities(Seq(createRequest).asJava, SparkUtils.ugi())
   }
 
   override protected def doDeleteEntityWithUniqueAttr(
       entityType: String,
       attribute: String): Unit = {
-    val deleteRequest = List(new EntityDeleteRequest(
+    val deleteRequest = new EntityDeleteRequestV2(
       SparkUtils.currUser(),
-      entityType,
-      org.apache.atlas.AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME,
-      attribute): HookNotification)
-    notifyEntities(deleteRequest.asJava, SparkUtils.ugi())
+      Seq(new AtlasObjectId(entityType,
+        org.apache.atlas.AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME,
+        attribute)).asJava
+    ): HookNotification
+
+    notifyEntities(Seq(deleteRequest).asJava, SparkUtils.ugi())
   }
 
   override protected def doUpdateEntityWithUniqueAttr(
       entityType: String,
       attribute: String,
       entity: AtlasEntity): Unit = {
-    val partialUpdateRequest = List(
-      new HookNotificationV1.EntityPartialUpdateRequest(
-        SparkUtils.currUser(),
-        entityType,
+    val partialUpdateRequest = new EntityPartialUpdateRequestV2(
+      SparkUtils.currUser(),
+      new AtlasObjectId(entityType,
         org.apache.atlas.AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME,
-        attribute,
-        entityToReferenceable(entity)): HookNotification)
-    notifyEntities(partialUpdateRequest.asJava, SparkUtils.ugi())
-  }
+        attribute),
+      new AtlasEntityWithExtInfo(entity)
+    ): HookNotification
 
-  private def entityToReferenceable(entity: AtlasEntity): Referenceable = {
-    val classifications = Option(entity.getClassifications).map { s =>
-      s.asScala.map(_.getTypeName)
-    }.getOrElse(List.empty)
-
-    val referenceable = new Referenceable(entity.getTypeName, classifications: _*)
-
-    val convertedAttributes = entity.getAttributes.asScala.mapValues {
-      case e: AtlasEntity =>
-        entityToReferenceable(e)
-
-      case l: util.Collection[_] =>
-        val list = new util.ArrayList[Referenceable]()
-        l.asScala.foreach {
-          case e: AtlasEntity =>
-            list.add(entityToReferenceable(e))
-        }
-        list
-
-      case o => o
-    }
-    convertedAttributes.foreach { kv => referenceable.set(kv._1, kv._2) }
-
-    referenceable
+    notifyEntities(Seq(partialUpdateRequest).asJava, SparkUtils.ugi())
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch changes Kafka Client (AtlasHook) to use API V2 which is already used in REST Client. This avoids possibility on errors while converting V1 to V2 in Atlas side.
Please refer #137 for more details.

## How was this patch tested?

Manual tests: verified against below scenarios with Spark 2.4/Atlas 1.1

1. Create/Alter/Delete table

```
spark.sql("create table test_spark_kafka_4 (col1 int)")
spark.sql("alter table test_spark_kafka_4 add columns (col2 int)")
spark.sql("drop table test_spark_kafka_4")
```

Table entity and relevant entities are created when executing `create table`, and table entity got removed when executing `drop table`.
"atlas.spark.column.enabled" is set to "true" when testing above queries. Column reference error occurred when updating spark_table which is expected, but col2 is added properly.


2. Run Kafka-to-Kafka streaming query

```
val bootstrapServers = "localhost:9092"
val checkpointLocation = "/tmp/mykafka3"
val sourceTopics = Seq("sparksource1hdp30", "sparksource2hdp30").mkString(",")
val sourceTopics2 = Seq("sparksource2hdp30", "sparksource3hdp30").mkString(",")
val targetTopic = "sparksinkhdp30"

val df = spark.readStream.format("kafka").option("kafka.bootstrap.servers", bootstrapServers).option("subscribe", sourceTopics).option("startingOffsets", "earliest").option("kafka.atlas.cluster.name", "source").load()

val df2 = spark.readStream.format("kafka").option("kafka.bootstrap.servers", bootstrapServers).option("subscribe", sourceTopics2).option("startingOffsets", "earliest").load()

df.union(df2).writeStream.format("kafka").option("kafka.bootstrap.servers", bootstrapServers).option("checkpointLocation", checkpointLocation).option("topic", targetTopic).option("kafka.atlas.cluster.name", "sink").start()
```

This closes #137 