### PR TITLE
[SAC-139] Apply "atlas.spark.column.enabled" for event AlterTable

### DIFF
--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessorSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessorSuite.scala
@@ -23,7 +23,6 @@ import java.nio.file.Files
 import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.language.postfixOps
-
 import com.sun.jersey.core.util.MultivaluedMapImpl
 import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.atlas.model.typedef.AtlasTypesDef
@@ -31,10 +30,9 @@ import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog._
-import org.apache.spark.sql.types.{LongType, StructType}
+import org.apache.spark.sql.types.{LongType, StringType, StructType}
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
-
 import com.hortonworks.spark.atlas.{AtlasClient, AtlasClientConf, TestUtils}
 import com.hortonworks.spark.atlas.utils.SparkUtils
 
@@ -135,6 +133,30 @@ class SparkCatalogEventProcessorSuite extends FunSuite with Matchers with Before
         assert(atlasClient.updateEntityCall(processor.columnType(isHiveTbl)) == 1)
       }
       assert(atlasClient.updateEntityCall(processor.tableType(isHiveTbl)) == 1)
+    }
+
+    val renamedTableDef = SparkUtils.getExternalCatalog().getTable("db1", "tbl2")
+
+    val newSchema = renamedTableDef.schema.add("COL1", StringType)
+    val newTableDefinition = renamedTableDef.copy(schema = newSchema)
+    SparkUtils.getExternalCatalog().alterTable(newTableDefinition)
+    processor.pushEvent(AlterTableEvent("db1", "tbl2", "table"))
+    eventually(timeout(30 seconds), interval(100 milliseconds)) {
+      assert(atlasClient.createEntityCall(processor.dbType) == 2)
+      assert(atlasClient.createEntityCall(processor.tableType(isHiveTbl)) == 2)
+      if (atlasClientConf.get(AtlasClientConf.ATLAS_SPARK_COLUMN_ENABLED).toBoolean) {
+        assert(atlasClient.createEntityCall(processor.columnType(isHiveTbl)) >= 2)
+        assert("col1" === atlasClient.processedEntity.getAttribute("name"))
+        assert(atlasClient.createEntityCall(processor.storageFormatType(isHiveTbl)) == 2)
+      }
+    }
+
+    processor.pushEvent(AlterTableEvent("db1", "tbl2", "dataSchema"))
+    eventually(timeout(30 seconds), interval(100 milliseconds)) {
+      if (atlasClientConf.get(AtlasClientConf.ATLAS_SPARK_COLUMN_ENABLED).toBoolean) {
+        assert(atlasClient.createEntityCall(processor.columnType(isHiveTbl)) >= 2)
+        assert(atlasClient.updateEntityCall(processor.tableType(isHiveTbl)) >= 2)
+      }
     }
 
     // SAC-97: Spark delete the table before SAC receives the message.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This addresses missing spot on handling "atlas.spark.column.enabled" for the event `AlterTable`.

## How was this patch tested?

Modified UT. Also done with manual test against below queries:

```
spark.sql("create table test_spark_kafka_b3 (col1 int)")
spark.sql("alter table test_spark_kafka_b3 add columns (col2 int)")
spark.sql("drop table test_spark_kafka_b3")
```

Before applying the patch, alter table query threw error on Atlas side, whereas this patch properly skips handling columns.

This closes #139 