### PR TITLE
[SAC-141] Make SAC recognise HWC's SQL API

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -475,8 +475,11 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
           // identifiers by this, it looks up Hive entities to find Hive tables out.
           val parsedPlan = org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parsePlan(sql)
           parsedPlan.collectLeaves().flatMap {
-            case r: UnresolvedRelation => external.hwcTableToEntities(
-              r.tableIdentifier.database.getOrElse("default"), r.tableIdentifier.table, clusterName)
+            case r: UnresolvedRelation =>
+              val db = r.tableIdentifier.database.getOrElse(
+                options.getOrElse("default.db", "default"))
+              val tableName = r.tableIdentifier.table
+              external.hwcTableToEntities(db, tableName, clusterName)
             case _: OneRowRelation => Seq.empty
             case n =>
               logWarn(s"Unknown leaf node: $n")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to make HWC's SQL syntax recognisable. Currently SAC and HWC only know the query that has to be pushed down to Hive side so here we don't know which tables are to be proceeded. To work around, we use Spark's parser driver to identify tables. Once we know the table identifiers by this, it looks up Hive entities to find Hive tables out.

## How was this patch tested?

Manually tested via a Yarn secure cluster.

![screen shot 2018-12-04 at 10 33 01 am](https://user-images.githubusercontent.com/6477701/49415466-d0d9b200-f7b1-11e8-9d53-9290746bd03c.png)

Closes #141 