### PR TITLE
[SAC-143] Make AtlasClient thread-safe to avoid duplicated entity creation

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClient.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClient.scala
@@ -35,7 +35,7 @@ trait AtlasClient extends Logging {
 
   def findEntity(typeNang: String, qualifiedName: String): AtlasEntity
 
-  final def createEntities(entities: Seq[AtlasEntity]): Unit = {
+  final def createEntities(entities: Seq[AtlasEntity]): Unit = this.synchronized {
     if (entities.isEmpty) {
       return
     }
@@ -50,7 +50,8 @@ trait AtlasClient extends Logging {
 
   protected def doCreateEntities(entities: Seq[AtlasEntity]): Unit
 
-  final def deleteEntityWithUniqueAttr(entityType: String, attribute: String): Unit = {
+  final def deleteEntityWithUniqueAttr(
+      entityType: String, attribute: String): Unit = this.synchronized {
     try {
       doDeleteEntityWithUniqueAttr(entityType, attribute)
     } catch {
@@ -64,7 +65,7 @@ trait AtlasClient extends Logging {
   final def updateEntityWithUniqueAttr(
       entityType: String,
       attribute: String,
-      entity: AtlasEntity): Unit = {
+      entity: AtlasEntity): Unit = this.synchronized {
     try {
       doUpdateEntityWithUniqueAttr(entityType, attribute, entity)
     } catch {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR make AtlasClient thread-safe to avoid duplicated entity creation. Currently, it is possible that the client makes duplicated entities since SAC has multiple threads that uses Atlas clients.

For instance, as below:

![image](https://user-images.githubusercontent.com/6477701/49584523-92e9b300-f996-11e8-9878-080e5cbb0f75.png)

## How was this patch tested?

Manually tested:

![screen shot 2018-12-06 at 8 40 00 pm](https://user-images.githubusercontent.com/6477701/49584723-20c59e00-f997-11e8-82ca-0e460f5c4ed1.png)

It's a bit tricky to add a test.

Closes #143 