### PR TITLE
[SAC-144] Refers catalog before creating spark_table entities when possible

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -217,9 +217,10 @@ object external {
   }
 
   def hiveTableToEntities(
-      tableDefinition: CatalogTable,
+      _tableDefinition: CatalogTable,
       cluster: String,
       mockDbDefinition: Option[CatalogDatabase] = None): Seq[AtlasEntity] = {
+    val tableDefinition = SparkUtils.getCatalogTableIfNeeded(_tableDefinition)
     val db = tableDefinition.identifier.database.getOrElse("default")
     val table = tableDefinition.identifier.table
     val dbDefinition = mockDbDefinition.getOrElse(SparkUtils.getExternalCatalog().getDatabase(db))

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -217,10 +217,10 @@ object external {
   }
 
   def hiveTableToEntities(
-      _tableDefinition: CatalogTable,
+      tblDefination: CatalogTable,
       cluster: String,
       mockDbDefinition: Option[CatalogDatabase] = None): Seq[AtlasEntity] = {
-    val tableDefinition = SparkUtils.getCatalogTableIfNeeded(_tableDefinition)
+    val tableDefinition = SparkUtils.getCatalogTableIfExistent(tblDefination)
     val db = tableDefinition.identifier.database.getOrElse("default")
     val table = tableDefinition.identifier.table
     val dbDefinition = mockDbDefinition.getOrElse(SparkUtils.getExternalCatalog().getDatabase(db))

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -100,10 +100,10 @@ object internal extends Logging {
   }
 
   def sparkTableToEntities(
-      _tableDefinition: CatalogTable,
+      tblDefination: CatalogTable,
       clusterName: String,
       mockDbDefinition: Option[CatalogDatabase] = None): Seq[AtlasEntity] = {
-    val tableDefinition = SparkUtils.getCatalogTableIfNeeded(_tableDefinition)
+    val tableDefinition = SparkUtils.getCatalogTableIfExistent(tblDefination)
     val db = tableDefinition.identifier.database.getOrElse("default")
     val dbDefinition = mockDbDefinition
       .getOrElse(SparkUtils.getExternalCatalog().getDatabase(db))

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -100,9 +100,10 @@ object internal extends Logging {
   }
 
   def sparkTableToEntities(
-      tableDefinition: CatalogTable,
+      _tableDefinition: CatalogTable,
       clusterName: String,
       mockDbDefinition: Option[CatalogDatabase] = None): Seq[AtlasEntity] = {
+    val tableDefinition = SparkUtils.getCatalogTableIfNeeded(_tableDefinition)
     val db = tableDefinition.identifier.database.getOrElse("default")
     val dbDefinition = mockDbDefinition
       .getOrElse(SparkUtils.getExternalCatalog().getDatabase(db))

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/utils/SparkUtils.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/utils/SparkUtils.scala
@@ -90,22 +90,17 @@ object SparkUtils extends Logging {
   }
 
   /**
-   * Get the catalog table of current active SparkSession if needed.
+   * Get the catalog table of current external catalog if exists; otherwise, it returns
+   * the input catalog table as is.
    */
-  def getCatalogTableIfNeeded(tableDefinition: CatalogTable): CatalogTable = {
-    // Let's assume that input catalog table does not have full information
-    // if both owner and last access time are default values (empty string and -1)
-    if (tableDefinition.owner == "" && tableDefinition.lastAccessTime == -1) {
-      try {
-        SparkUtils.getExternalCatalog().getTable(
-          tableDefinition.identifier.database.getOrElse("default"),
-          tableDefinition.identifier.table)
-      } catch {
-        case e: Throwable =>
-          tableDefinition
-      }
-    } else {
-      tableDefinition
+  def getCatalogTableIfExistent(tableDefinition: CatalogTable): CatalogTable = {
+    try {
+      SparkUtils.getExternalCatalog().getTable(
+        tableDefinition.identifier.database.getOrElse("default"),
+        tableDefinition.identifier.table)
+    } catch {
+      case e: Throwable =>
+        tableDefinition
     }
   }
 

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateDataSourceTableAsSelectHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateDataSourceTableAsSelectHarvesterSuite.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql
+
+import scala.util.Random
+
+import com.hortonworks.spark.atlas.WithHiveSupport
+import com.hortonworks.spark.atlas.utils.SparkUtils
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.execution.command.CreateDataSourceTableAsSelectCommand
+import org.apache.spark.sql.execution.datasources.DataSource
+import org.apache.spark.sql.types.StructType
+import org.scalatest.{FunSuite, Matchers}
+
+
+class CreateDataSourceTableAsSelectHarvesterSuite
+    extends FunSuite with Matchers with WithHiveSupport {
+
+  private val sourceTblName = "source_" + Random.nextInt(100000)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+
+    sparkSession.sql(s"CREATE TABLE $sourceTblName (name string, age int)")
+  }
+
+  test("saveAsTable should have output entity having table details") {
+    val destTblName = "dest1_" + Random.nextInt(100000)
+    val df = sparkSession.sql(s"SELECT * FROM $sourceTblName")
+
+    // The codes below look after DataFrameWriter.saveAsTable codes as of Spark 2.4.
+    // It uses internal APIs for this test. If the compatibility is broken, we should better
+    // just remove this test.
+    val tableIdent = df.sparkSession.sessionState.sqlParser.parseTableIdentifier(destTblName)
+    val storage = DataSource.buildStorageFormatFromOptions(Map("path" -> "/tmp/foo"))
+    val tableDesc = CatalogTable(
+      identifier = tableIdent,
+      tableType = CatalogTableType.EXTERNAL,
+      storage = storage,
+      schema = new StructType,
+      provider = Some("parquet"),
+      partitionColumnNames = Nil,
+      bucketSpec = None)
+    val cmd = CreateDataSourceTableAsSelectCommand(
+      tableDesc,
+      SaveMode.ErrorIfExists,
+      df.queryExecution.logical,
+      Seq("name", "age"))
+    val newTable = tableDesc.copy(
+      storage = tableDesc.storage.copy(),
+      schema = df.schema)
+    sparkSession.sessionState.catalog.createTable(
+      newTable, ignoreIfExists = false, validateLocation = false)
+
+    val qd = QueryDetail(df.queryExecution, 0L, 0L)
+    val entities = CommandsHarvester.CreateDataSourceTableAsSelectHarvester.harvest(cmd, qd)
+    val maybeEntity = entities.find(e => e.getTypeName == "spark_table")
+
+    assert(maybeEntity.isDefined, s"Output entity for table [$destTblName] was not found.")
+    assert(maybeEntity.get.getAttribute("name") == destTblName)
+    assert(maybeEntity.get.getAttribute("owner") == SparkUtils.currUser())
+  }
+}

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForBatchQuerySuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForBatchQuerySuite.scala
@@ -85,16 +85,17 @@ class SparkExecutionPlanProcessorForBatchQuerySuite extends StreamTest {
 
     val databaseLocationFsEntity = getAtlasEntityAttribute(databaseEntity, "locationUri")
 
-    // we're expecting two file system entities:
-    // one for input file, another one for database warehouse
+    // we're expecting three file system entities:
+    // one for input file, one for database warehouse, and one for output table (under
+    // database warehouse since it's a managed table).
     val fsEntities = listAtlasEntitiesAsType(entities, external.FS_PATH_TYPE_STRING)
-    assert(fsEntities.size === 2)
+    assert(fsEntities.size === 3)
 
     // database warehouse
     assert(fsEntities.contains(databaseLocationFsEntity))
 
     val inputFsEntities = fsEntities.filterNot(_ == databaseLocationFsEntity)
-    assert(inputFsEntities.size === 1)
+    assert(inputFsEntities.size === 2)
 
     // input file
     val inputFsEntity = inputFsEntities.head


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to refer catalog before creating spark_table entities when possible. Looks there could be `CatalogTable` being passed as kind of a dummy in some places in Spark.

For instance, see the test added that mimics `DataFrameWriter.saveAsTable` code path. It causes missing table information as below:

![screen shot 2018-12-06 at 8 38 44 pm](https://user-images.githubusercontent.com/6477701/49584778-5ec2c200-f997-11e8-9986-0a66c73e6531.png)

## How was this patch tested?

Unit test added to describe what happens and prevent regression. Manually tested as well:

![screen shot 2018-12-06 at 7 33 49 pm](https://user-images.githubusercontent.com/6477701/49584674-fecc1b80-f996-11e8-9ec2-1bdd361cd520.png)

Closes #144 