### PR TITLE
[SAC-150][SQL] Drop attribute 'lastAccessTime' in table

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -239,7 +239,6 @@ object external {
     tblEntity.setAttribute("owner", tableDefinition.owner)
     tblEntity.setAttribute("ownerType", "USER")
     tblEntity.setAttribute("createTime", new Date(tableDefinition.createTime))
-    tblEntity.setAttribute("lastAccessTime", new Date(tableDefinition.lastAccessTime))
     tableDefinition.comment.foreach(tblEntity.setAttribute("comment", _))
     tblEntity.setAttribute("db", dbEntities.head)
     tblEntity.setAttribute("sd", sdEntities.head)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -130,7 +130,6 @@ object internal extends Logging {
     tblEntity.setAttribute("owner", tableDefinition.owner)
     tblEntity.setAttribute("ownerType", "USER")
     tblEntity.setAttribute("createTime", tableDefinition.createTime)
-    tblEntity.setAttribute("lastAccessTime", tableDefinition.lastAccessTime)
     tblEntity.setAttribute("properties", tableDefinition.properties.asJava)
     tableDefinition.comment.foreach(tblEntity.setAttribute("comment", _))
     tblEntity.setAttribute("unsupportedFeatures", tableDefinition.unsupportedFeatures.asJava)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
@@ -112,7 +112,6 @@ object metadata {
     AtlasTypeUtil.createOptionalAttrDef("owner", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("ownerType", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("createTime", new AtlasLongType),
-    AtlasTypeUtil.createOptionalAttrDef("lastAccessTime", new AtlasLongType),
     AtlasTypeUtil.createOptionalAttrDef(
       "properties", new AtlasMapType(new AtlasStringType, new AtlasStringType)),
     AtlasTypeUtil.createOptionalAttrDef("comment", new AtlasStringType),


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes dropping attribute 'lastAccessTime' in table entity due to difficulty of updating such attribute.

Please refer #150 for more details on the decision.

## How was this patch tested?

Manually tested with Atlas 1.1 (embedded HBase/Solr/Kafka) & Spark 2.4.

![screen shot 2018-12-10 at 2 39 36 pm](https://user-images.githubusercontent.com/1317309/49712807-8b255980-fc89-11e8-8b7c-9b8cce8fa5e5.png)

This closes #150.