### PR TITLE
[SAC-152][SQL] Support `atlas.cluster.name` option for HBase entity

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -335,12 +335,13 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       var catalog = ""
       node.options.foreach {x => if (x._1.equals("catalog")) catalog = x._2}
       val outputEntities = if (catalog != "") {
+        val cluster = node.options.getOrElse(AtlasClientConf.CLUSTER_NAME.key, clusterName)
         val jObj = parse(catalog).asInstanceOf[JObject]
         val map = jObj.values
         val tableMeta = map.get("table").get.asInstanceOf[Map[String, _]]
         val nSpace = tableMeta.getOrElse("namespace", "default").asInstanceOf[String]
         val tName = tableMeta.get("name").get.asInstanceOf[String]
-        external.hbaseTableToEntity(conf.get(AtlasClientConf.CLUSTER_NAME), tName, nSpace)
+        external.hbaseTableToEntity(cluster, tName, nSpace)
       } else {
         Seq.empty
       }
@@ -372,14 +373,16 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
 
   private def getHBaseEntity(r: BaseRelation): Seq[AtlasEntity] = {
     if (maybeClazz.isDefined) {
-      val parameters = r.getClass.getMethod("parameters").invoke(r)
-      val catalog = parameters.asInstanceOf[Map[String, String]].getOrElse("catalog", "")
+      val parameters =
+        r.getClass.getMethod("parameters").invoke(r).asInstanceOf[Map[String, String]]
+      val catalog = parameters.getOrElse("catalog", "")
+      val cluster = parameters.getOrElse(AtlasClientConf.CLUSTER_NAME.key, clusterName)
       val jObj = parse(catalog).asInstanceOf[JObject]
       val map = jObj.values
       val tableMeta = map.get("table").get.asInstanceOf[Map[String, _]]
       val nSpace = tableMeta.getOrElse("namespace", "default").asInstanceOf[String]
       val tName = tableMeta.get("name").get.asInstanceOf[String]
-      external.hbaseTableToEntity(clusterName, tName, nSpace)
+      external.hbaseTableToEntity(cluster, tName, nSpace)
     } else {
       logWarn(s"Class $maybeClazz is not found")
       Seq.empty


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to support multi HBase cluster use cases by accepting `atlas.cluster.name` from users. The basic usage is the same with Kafka.
```scala
df.write
  .format("org.apache.spark.sql.execution.datasources.hbase")
  .option("catalog", cat)
  .option("atlas.cluster.name", "customClusterName")
  .save()
```

![atlas cluster name option](https://user-images.githubusercontent.com/9700541/49846029-2697f680-fd7e-11e8-826d-2e74230a195a.png)

## How was this patch tested?

Manual. (This is tested manually with Apache Spark 2.4/Apache Atlas 1.1 with embedded HBase.)

This closes #152 .