### PR TITLE
[SAC-154][SQL] Create only table and columns entities (if enabled) for alter table event

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasUtils.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasUtils.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas
+
+import org.apache.atlas.model.instance.{AtlasEntity, AtlasObjectId}
+
+object AtlasUtils {
+
+  def entityToReference(entity: AtlasEntity, useGuid: Boolean = false): AtlasObjectId = {
+    if (useGuid) {
+      new AtlasObjectId(entity.getGuid)
+    } else {
+      new AtlasObjectId(entity.getTypeName, "qualifiedName", entity.getAttribute("qualifiedName"))
+    }
+  }
+}

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessor.scala
@@ -171,7 +171,7 @@ class SparkCatalogEventProcessor(
         val tableDefinition = SparkUtils.getExternalCatalog().getTable(db, table)
         kind match {
           case "table" =>
-            val tableEntities = tableToEntities(tableDefinition)
+            val tableEntities = tableToEntitiesForAlterTable(tableDefinition)
             if (conf.get(AtlasClientConf.ATLAS_SPARK_COLUMN_ENABLED).toBoolean) {
               atlasClient.createEntities(tableEntities)
               logDebug(s"Updated table entity $table with columns")

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/AtlasEntityUtils.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/AtlasEntityUtils.scala
@@ -136,6 +136,16 @@ trait AtlasEntityUtils {
     }
   }
 
+  def tableToEntitiesForAlterTable(
+      tableDefinition: CatalogTable,
+      mockDbDefinition: Option[CatalogDatabase] = None): Seq[AtlasEntity] = {
+    if (isHiveTable(tableDefinition)) {
+      external.hiveTableToEntitiesForAlterTable(tableDefinition, clusterName, mockDbDefinition)
+    } else {
+      internal.sparkTableToEntitiesForAlterTable(tableDefinition, clusterName, mockDbDefinition)
+    }
+  }
+
   def tableUniqueAttribute(db: String, table: String, isHiveTable: Boolean): String = {
     if (isHiveTable) {
       external.hiveTableUniqueAttribute(clusterName, db, table)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -17,16 +17,16 @@
 
 package com.hortonworks.spark.atlas.types
 
+import com.hortonworks.spark.atlas.AtlasUtils
+import com.hortonworks.spark.atlas.types.external.{HIVE_DB_TYPE_STRING, HIVE_STORAGEDESC_TYPE_STRING, HIVE_TABLE_TYPE_STRING}
+
 import scala.collection.mutable
 import scala.collection.JavaConverters._
-
 import org.apache.atlas.AtlasConstants
 import org.apache.atlas.model.instance.AtlasEntity
-
 import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogStorageFormat, CatalogTable}
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.types.StructType
-
 import com.hortonworks.spark.atlas.utils.{Logging, SparkUtils}
 
 object internal extends Logging {
@@ -136,6 +136,24 @@ object internal extends Logging {
     tblEntity.setAttribute("unsupportedFeatures", tableDefinition.unsupportedFeatures.asJava)
 
     Seq(tblEntity) ++ dbEntities ++ sdEntities ++ schemaEntities
+  }
+
+  def sparkTableToEntitiesForAlterTable(
+      tblDefination: CatalogTable,
+      clusterName: String,
+      mockDbDefinition: Option[CatalogDatabase] = None): Seq[AtlasEntity] = {
+    val typesToPick = Seq(metadata.TABLE_TYPE_STRING, metadata.COLUMN_TYPE_STRING)
+    val entities = sparkTableToEntities(tblDefination, clusterName, mockDbDefinition)
+
+    val dbEntity = entities.filter(e => e.getTypeName.equals(metadata.DB_TYPE_STRING)).head
+    val sdEntity = entities.filter(e => e.getTypeName.equals(metadata.STORAGEDESC_TYPE_STRING)).head
+    val tableEntity = entities.filter(e => e.getTypeName.equals(metadata.TABLE_TYPE_STRING)).head
+
+    // override attribute with reference - Atlas should already have these entities
+    tableEntity.setAttribute("db", AtlasUtils.entityToReference(dbEntity, useGuid = false))
+    tableEntity.setAttribute("sd", AtlasUtils.entityToReference(sdEntity, useGuid = false))
+
+    entities.filter(e => typesToPick.contains(e.getTypeName))
   }
 
   def sparkProcessUniqueAttribute(executionId: Long): String = {

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessorSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessorSuite.scala
@@ -142,7 +142,10 @@ class SparkCatalogEventProcessorSuite extends FunSuite with Matchers with Before
     SparkUtils.getExternalCatalog().alterTable(newTableDefinition)
     processor.pushEvent(AlterTableEvent("db1", "tbl2", "table"))
     eventually(timeout(30 seconds), interval(100 milliseconds)) {
-      assert(atlasClient.createEntityCall(processor.dbType) == 2)
+      // no creation on db type and storage format entities
+      assert(atlasClient.createEntityCall(processor.dbType) == 1)
+      assert(atlasClient.createEntityCall(processor.storageFormatType(isHiveTbl)) == 1)
+
       assert(atlasClient.createEntityCall(processor.tableType(isHiveTbl)) == 2)
       if (atlasClientConf.get(AtlasClientConf.ATLAS_SPARK_COLUMN_ENABLED).toBoolean) {
         assert(atlasClient.createEntityCall(processor.columnType(isHiveTbl)) >= 2)
@@ -153,6 +156,10 @@ class SparkCatalogEventProcessorSuite extends FunSuite with Matchers with Before
 
     processor.pushEvent(AlterTableEvent("db1", "tbl2", "dataSchema"))
     eventually(timeout(30 seconds), interval(100 milliseconds)) {
+      // no creation on db type and storage format entities
+      assert(atlasClient.createEntityCall(processor.dbType) == 1)
+      assert(atlasClient.createEntityCall(processor.storageFormatType(isHiveTbl)) == 1)
+
       if (atlasClientConf.get(AtlasClientConf.ATLAS_SPARK_COLUMN_ENABLED).toBoolean) {
         assert(atlasClient.createEntityCall(processor.columnType(isHiveTbl)) >= 2)
         assert(atlasClient.updateEntityCall(processor.tableType(isHiveTbl)) >= 2)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes to separate handling of `create table` and `alter table`, and avoid creating entities for database and storagedesc for the event of `alter table`.

## How was this patch tested?

Modified UT to ensure database and storagedesc entities are not created during alter table event.
Also manually tested with Atlas 1.1 & Spark 2.4 to ensure there's no audit update on both database and storagedesc entities.

* table entity
![screen shot 2018-12-12 at 1 38 12 pm](https://user-images.githubusercontent.com/1317309/49848118-f18bb280-fe16-11e8-9768-8891b23d0343.png)

* db entity
![screen shot 2018-12-12 at 1 38 01 pm](https://user-images.githubusercontent.com/1317309/49848124-f8b2c080-fe16-11e8-9d56-b6d5f37e6bd7.png)

* storage entity
![screen shot 2018-12-12 at 1 37 46 pm](https://user-images.githubusercontent.com/1317309/49848135-0405ec00-fe17-11e8-8e9f-bc41fd35e307.png)

Please look for create/update on `Wed Dec 12 2018 13:37:09`. Audit is only added to table.

This closes #154 