### PR TITLE
[SAC-156] Spark 2.3 - Support custom atlas cluster name for Kafka topics (source/sink)

### DIFF
--- a/patch/Spark_Kafka_Custom_Atlas_Cluster_Name_2.3.diff
+++ b/patch/Spark_Kafka_Custom_Atlas_Cluster_Name_2.3.diff
@@ -1,0 +1,13 @@
+diff --git a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+index ca05b9e8d3..4be749cff0 100644
+--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
++++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+@@ -60,7 +60,7 @@ private[kafka010] case class KafkaSourceRDDPartition(
+  */
+ private[kafka010] class KafkaSourceRDD(
+     sc: SparkContext,
+-    executorKafkaParams: ju.Map[String, Object],
++    val executorKafkaParams: ju.Map[String, Object],
+     offsetRanges: Seq[KafkaSourceRDDOffsetRange],
+     pollTimeoutMs: Long,
+     failOnDataLoss: Boolean,

--- a/patch/Spark_Kafka_Custom_Atlas_Cluster_Name_2.3.patch
+++ b/patch/Spark_Kafka_Custom_Atlas_Cluster_Name_2.3.patch
@@ -1,0 +1,23 @@
+From 6639ee0a8a3b2f43610288c24605ae6f9e176e62 Mon Sep 17 00:00:00 2001
+From: Jungtaek Lim (HeartSaVioR) <kabhwan@gmail.com>
+Date: Wed, 12 Dec 2018 19:49:09 +0900
+Subject: [PATCH] [BUG-115910][SS] Expose kafka params as field value in KafkaSourceRDD
+
+* This is for enabling custom atlas cluster name to Kafka source/sink in Atlas
+
+Change-Id: I62baf12913e21e318fe64619c1d84e895d46379f
+---
+
+diff --git a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+index ca05b9e..4be749c 100644
+--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
++++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+@@ -60,7 +60,7 @@
+  */
+ private[kafka010] class KafkaSourceRDD(
+     sc: SparkContext,
+-    executorKafkaParams: ju.Map[String, Object],
++    val executorKafkaParams: ju.Map[String, Object],
+     offsetRanges: Seq[KafkaSourceRDDOffsetRange],
+     pollTimeoutMs: Long,
+     failOnDataLoss: Boolean,

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.types.StructType
 
 import com.hortonworks.spark.atlas.{AtlasClient, AtlasUtils}
 import com.hortonworks.spark.atlas.utils.SparkUtils
+import org.apache.spark.sql.kafka010.atlas.KafkaTopicInformation
 
 object external {
   // External metadata types used to link with external entities
@@ -100,14 +101,19 @@ object external {
   // ================ Kafka entities =======================
   val KAFKA_TOPIC_STRING = "kafka_topic"
 
-  def kafkaToEntity(cluster: String, topicName: String): Seq[AtlasEntity] = {
+  def kafkaToEntity(cluster: String, topic: KafkaTopicInformation): Seq[AtlasEntity] = {
+    val topicName = topic.topicName.toLowerCase
+    val clusterName = topic.clusterName match {
+      case Some(customName) => customName
+      case None => cluster
+    }
+
     val kafkaEntity = new AtlasEntity(KAFKA_TOPIC_STRING)
-    kafkaEntity.setAttribute("qualifiedName",
-      topicName.toLowerCase + '@' + cluster)
-    kafkaEntity.setAttribute("name", topicName.toLowerCase)
-    kafkaEntity.setAttribute(AtlasConstants.CLUSTER_NAME_ATTRIBUTE, cluster)
-    kafkaEntity.setAttribute("uri", topicName.toLowerCase)
-    kafkaEntity.setAttribute("topic", topicName.toLowerCase)
+    kafkaEntity.setAttribute("qualifiedName", topicName + '@' + clusterName)
+    kafkaEntity.setAttribute("name", topicName)
+    kafkaEntity.setAttribute(AtlasConstants.CLUSTER_NAME_ATTRIBUTE, clusterName)
+    kafkaEntity.setAttribute("uri", topicName)
+    kafkaEntity.setAttribute("topic", topicName)
     Seq(kafkaEntity)
   }
 

--- a/spark-atlas-connector/src/main/scala/org/apache/spark/sql/kafka010/atlas/KafkaHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/org/apache/spark/sql/kafka010/atlas/KafkaHarvester.scala
@@ -18,36 +18,44 @@
 package org.apache.spark.sql.kafka010.atlas
 
 import scala.collection.mutable
-
 import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.spark.sql.execution.RDDScanExec
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceRDDPartition, DataSourceV2ScanExec, WriteToDataSourceV2Exec}
 import org.apache.spark.sql.execution.streaming.sources.InternalRowMicroBatchWriter
-import org.apache.spark.sql.kafka010._
-
+import org.apache.spark.sql.kafka010.{KafkaContinuousDataReaderFactory, KafkaSourceRDD, KafkaSourceRDDPartition, KafkaStreamWriterFactory}
 import com.hortonworks.spark.atlas.AtlasClientConf
 import com.hortonworks.spark.atlas.sql.QueryDetail
 import com.hortonworks.spark.atlas.types.{AtlasEntityUtils, external, internal}
 import com.hortonworks.spark.atlas.utils.{Logging, SparkUtils}
 
+import scala.util.control.NonFatal
+
 
 object KafkaHarvester extends AtlasEntityUtils with Logging {
   override val conf: AtlasClientConf = new AtlasClientConf
 
-  def extractTopic(writer: InternalRowMicroBatchWriter): (Boolean, Option[String]) = {
+  // reflection
+  import scala.reflect.runtime.universe.{runtimeMirror, typeOf, TermName}
+  private val currentMirror = runtimeMirror(getClass.getClassLoader)
+
+  def extractTopic(writer: InternalRowMicroBatchWriter)
+    : (Boolean, Option[KafkaTopicInformation]) = {
     // Unfortunately neither KafkaStreamWriter is a case class nor topic is a field.
     // Hopefully KafkaStreamWriterFactory is a case class instead, so we can extract
     // topic information from there.
     // The cost of createInternalRowWriterFactory is tiny (case class object creation)
     // for this case, and we can find the way to cache it once we find the cost is not ignorable.
     writer.createInternalRowWriterFactory() match {
-      case KafkaStreamWriterFactory(tp, _, _) => (true, tp)
+      case KafkaStreamWriterFactory(Some(tp), params, _) =>
+        (true, Some(KafkaTopicInformation(tp, params.get(AtlasClientConf.CLUSTER_NAME.key))))
       case _ => (false, None)
     }
   }
 
-  def harvest(targetTopic: Option[String], writer: WriteToDataSourceV2Exec,
-              qd: QueryDetail) : Seq[AtlasEntity] = {
+  def harvest(
+      targetTopic: Option[KafkaTopicInformation],
+      writer: WriteToDataSourceV2Exec,
+      qd: QueryDetail) : Seq[AtlasEntity] = {
     // source topics - can be multiple topics
     val sourceTopics = extractSourceTopics(writer)
     val inputsEntities: Seq[AtlasEntity] = extractInputEntities(sourceTopics)
@@ -62,7 +70,7 @@ object KafkaHarvester extends AtlasEntityUtils with Logging {
     makeProcessEntities(inputsEntities, outputEntities, logMap)
   }
 
-  def extractSourceTopics(node: WriteToDataSourceV2Exec): Set[String] = {
+  def extractSourceTopics(node: WriteToDataSourceV2Exec): Set[KafkaTopicInformation] = {
     node.query.flatMap {
       case r: RDDScanExec => extractSourceTopicsFromDataSourceV1(r)
       case r: DataSourceV2ScanExec => extractSourceTopicsFromDataSourceV2(r)
@@ -71,21 +79,24 @@ object KafkaHarvester extends AtlasEntityUtils with Logging {
   }
 
   def extractInputEntities(
-       sourceTopics: Set[String]): Seq[AtlasEntity] = {
+       sourceTopics: Set[KafkaTopicInformation]): Seq[AtlasEntity] = {
     sourceTopics
       .toList.flatMap { topic => external.kafkaToEntity(clusterName, topic) }
   }
 
   def makeLogMap(
-      sourceTopics: Set[String],
-      targetTopic: Option[String],
+      sourceTopics: Set[KafkaTopicInformation],
+      targetTopic: Option[KafkaTopicInformation],
       qd: QueryDetail): Map[String, String] = {
     // create process entity
-    val strSourceTopics = sourceTopics.toList.sorted.mkString(", ")
+    val strSourceTopics = sourceTopics.toList
+      .map(KafkaTopicInformation.getQualifiedName(_, clusterName)).sorted.mkString(", ")
+
     val pDescription = StringBuilder.newBuilder.append(s"Topics subscribed( $strSourceTopics )")
 
     if (targetTopic.isDefined) {
-      pDescription.append(s" Topics written into( ${targetTopic.get} )")
+      val strTargetTopic = KafkaTopicInformation.getQualifiedName(targetTopic.get, clusterName)
+      pDescription.append(s" Topics written into( $strTargetTopic )")
     } else {
       logInfo(s"Can not get dest topic")
     }
@@ -120,24 +131,57 @@ object KafkaHarvester extends AtlasEntityUtils with Logging {
     }
   }
 
-  private def extractSourceTopicsFromDataSourceV1(r: RDDScanExec) = {
-    val topics = new mutable.HashSet[String]()
+  private def extractSourceTopicsFromDataSourceV1(r: RDDScanExec): Seq[KafkaTopicInformation] = {
+    def extractKafkaParams(rdd: KafkaSourceRDD): Option[java.util.Map[String, Object]] = {
+      val rddMirror = currentMirror.reflect(rdd)
+
+      try {
+        val kafkaParamsMethod = typeOf[KafkaSourceRDD].decl(TermName("executorKafkaParams"))
+          .asTerm.accessed.asTerm
+
+        Some(rddMirror.reflectField(kafkaParamsMethod).get
+          .asInstanceOf[java.util.Map[String, Object]])
+      } catch {
+        case NonFatal(_) =>
+          logWarn("WARN: Necessary patch for spark-sql-kafka doesn't look like applied to Spark. " +
+            "Giving up extracting kafka parameter.")
+          None
+      }
+    }
+
+    val topics = new mutable.HashSet[KafkaTopicInformation]()
     r.rdd.partitions.foreach {
       case e: KafkaSourceRDDPartition =>
-        val topic = e.offsetRange.topic
-        topics += topic
+        r.rdd.dependencies.find(p => p.rdd.isInstanceOf[KafkaSourceRDD]).map(_.rdd) match {
+          case Some(kafkaRDD: KafkaSourceRDD) =>
+            val topic = e.offsetRange.topic
+            val customClusterName = extractKafkaParams(kafkaRDD) match {
+              case Some(params) => Option(params.get(AtlasClientConf.CLUSTER_NAME.key))
+                .map(_.toString)
+              case None => None
+            }
+            topics += KafkaTopicInformation(topic, customClusterName)
+
+          case _ =>
+            topics += KafkaTopicInformation(e.offsetRange.topic, None)
+        }
+
+      case _ =>
     }
-    topics
+    topics.toSeq
   }
 
-  private def extractSourceTopicsFromDataSourceV2(r: DataSourceV2ScanExec) = {
-    val topics = new mutable.HashSet[String]()
+  private def extractSourceTopicsFromDataSourceV2(r: DataSourceV2ScanExec)
+    : Seq[KafkaTopicInformation] = {
+    val topics = new mutable.HashSet[KafkaTopicInformation]()
     r.inputRDDs().foreach(rdd => rdd.partitions.foreach {
       case e: DataSourceRDDPartition[_] =>
         e.readerFactory match {
           case e1: KafkaContinuousDataReaderFactory =>
             val topic = e1.topicPartition.topic()
-            topics += topic
+            val customClusterName = e1.kafkaParams.get(AtlasClientConf.CLUSTER_NAME.key)
+              .asInstanceOf[String]
+            topics += KafkaTopicInformation(topic, Option(customClusterName))
 
           case _ =>
         }
@@ -145,6 +189,6 @@ object KafkaHarvester extends AtlasEntityUtils with Logging {
       case _ =>
     })
 
-    topics
+    topics.toSeq
   }
 }

--- a/spark-atlas-connector/src/main/scala/org/apache/spark/sql/kafka010/atlas/KafkaTopicInformation.scala
+++ b/spark-atlas-connector/src/main/scala/org/apache/spark/sql/kafka010/atlas/KafkaTopicInformation.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kafka010.atlas
+
+case class KafkaTopicInformation(topicName: String, clusterName: Option[String] = None)
+
+object KafkaTopicInformation {
+  def getQualifiedName(ti: KafkaTopicInformation, defaultClusterName: String): String = {
+    val cName = ti.clusterName.getOrElse(defaultClusterName)
+    s"${ti.topicName}@$cName"
+  }
+}

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
@@ -59,6 +59,7 @@ class SparkExecutionPlanProcessorForStreamingQuerySuite extends StreamTest {
   }
 
   test("Kafka source(s) to kafka sink - micro-batch query") {
+    // NOTE: We can't test custom Atlas cluster here, because it requires Spark 2.3 to be patched.
     val planProcessor = new DirectProcessSparkExecutionPlanProcessor(atlasClient, atlasClientConf)
 
     val topicsToRead = Seq("sparkread1", "sparkread2", "sparkread3")
@@ -127,7 +128,7 @@ class SparkExecutionPlanProcessorForStreamingQuerySuite extends StreamTest {
   }
 
   private def waitForBatchCompleted(query: StreamingQuery, listener: AtlasQueryExecutionListener)
-  : Unit = {
+    : Unit = {
     import org.scalatest.time.SpanSugar._
     eventually(timeout(10.seconds)) {
       query.processAllAvailable()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes applying #103 against Spark 2.3 as well. Previously we dropped applying Spark 2.3 because it requires custom patch for Spark 2.3, and now we just decided to proceed with custom patch. 

This patch leverages reflection to access newly exposed field. If Spark is not patched, SAC will print out WARN message and will not extract custom atlas cluster name.

## How was this patch tested?

Manually tested against Atlas 1.1 & Spark 2.3.2 & patched spark-sql-kafka 2.3.2.

```
val sourceTopics = Seq("sparksource1-20181213", "sparksource2-20181213", "sparksource3-20181213").mkString(",")
val targetTopic = "sparksink-20181213"

val df = spark.readStream.format("kafka").option("kafka.bootstrap.servers", bootstrapServers)
  .option("subscribe", sourceTopics).option("startingOffsets", "earliest")
  .option("kafka.atlas.cluster.name", "sourceCluster").load()

df.writeStream.format("kafka").option("kafka.bootstrap.servers", bootstrapServers)
  .option("checkpointLocation", checkpointLocation).option("topic", targetTopic)
  .option("kafka.atlas.cluster.name", "sinkCluster").start()
```

This records Kafka topic entities as well as Spark process entity like below. In qualifiedName in Kafka topic entities, custom atlas cluster names are applied.

<img width="899" alt="screen shot 2018-12-13 at 2 12 46 pm" src="https://user-images.githubusercontent.com/1317309/49918162-6f1df400-fee5-11e8-8f87-084ea4482db1.png">
<img width="891" alt="screen shot 2018-12-13 at 2 12 26 pm" src="https://user-images.githubusercontent.com/1317309/49918167-747b3e80-fee5-11e8-9e15-615ddfa5945e.png">
<img width="900" alt="screen shot 2018-12-13 at 2 12 17 pm" src="https://user-images.githubusercontent.com/1317309/49918171-7c3ae300-fee5-11e8-87f0-75cb4684a8b9.png">

This closes #156
