### PR TITLE
[SAC-156] Spark 2.3 - Support custom atlas cluster name for Kafka topics (source/sink)

### DIFF
--- a/patch/Spark_Kafka_Custom_Atlas_Cluster_Name_2.3.diff
+++ b/patch/Spark_Kafka_Custom_Atlas_Cluster_Name_2.3.diff
@@ -1,0 +1,13 @@
+diff --git a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+index ca05b9e8d3..4be749cff0 100644
+--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
++++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+@@ -60,7 +60,7 @@ private[kafka010] case class KafkaSourceRDDPartition(
+  */
+ private[kafka010] class KafkaSourceRDD(
+     sc: SparkContext,
+-    executorKafkaParams: ju.Map[String, Object],
++    val executorKafkaParams: ju.Map[String, Object],
+     offsetRanges: Seq[KafkaSourceRDDOffsetRange],
+     pollTimeoutMs: Long,
+     failOnDataLoss: Boolean,

--- a/patch/Spark_Kafka_Custom_Atlas_Cluster_Name_2.3.patch
+++ b/patch/Spark_Kafka_Custom_Atlas_Cluster_Name_2.3.patch
@@ -1,0 +1,23 @@
+From 6639ee0a8a3b2f43610288c24605ae6f9e176e62 Mon Sep 17 00:00:00 2001
+From: Jungtaek Lim (HeartSaVioR) <kabhwan@gmail.com>
+Date: Wed, 12 Dec 2018 19:49:09 +0900
+Subject: [PATCH] [BUG-115910][SS] Expose kafka params as field value in KafkaSourceRDD
+
+* This is for enabling custom atlas cluster name to Kafka source/sink in Atlas
+
+Change-Id: I62baf12913e21e318fe64619c1d84e895d46379f
+---
+
+diff --git a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+index ca05b9e..4be749c 100644
+--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
++++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+@@ -60,7 +60,7 @@
+  */
+ private[kafka010] class KafkaSourceRDD(
+     sc: SparkContext,
+-    executorKafkaParams: ju.Map[String, Object],
++    val executorKafkaParams: ju.Map[String, Object],
+     offsetRanges: Seq[KafkaSourceRDDOffsetRange],
+     pollTimeoutMs: Long,
+     failOnDataLoss: Boolean,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes applying #103 against Spark 2.3 as well. Previously we dropped applying Spark 2.3 because it requires custom patch for Spark 2.3, and now we just decided to proceed with custom patch. 

This patch leverages reflection to access newly exposed field. If Spark is not patched, SAC will print out WARN message and will not extract custom atlas cluster name.

## How was this patch tested?

The change of this patch is verified from #157 which is only used when dealing with Spark 2.3. In Spark 2.4 it will not be used.

This closes #156