### PR TITLE
[SAC-163][BUILD] Shade Atlas's hbase/htrace dependencies

### DIFF
--- a/spark-atlas-connector-assembly/pom.xml
+++ b/spark-atlas-connector-assembly/pom.xml
@@ -81,6 +81,16 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
               </transformers>
+              <relocations>
+                <relocation>
+                  <pattern>org.apache.hadoop.hbase</pattern>
+                  <shadedPattern>org.apache.atlas.hbase</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.htrace</pattern>
+                  <shadedPattern>org.apache.atlas.htrace</shadedPattern>
+                </relocation>
+              </relocations>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR shades Atlas's HBase/HTrace dependencies to avoid conflicts with Spark HBase Connectors.

## How was this patch tested?

Pass the build and tests in Travis. (Also, this is tested in the cluster).