### PR TITLE
[SAC-168][SQL] Apply Spark catalog model definitions to Hive catalog entities

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -18,7 +18,6 @@
 package com.hortonworks.spark.atlas.types
 
 import com.hortonworks.spark.atlas.AtlasUtils
-import com.hortonworks.spark.atlas.types.external.{HIVE_DB_TYPE_STRING, HIVE_STORAGEDESC_TYPE_STRING, HIVE_TABLE_TYPE_STRING}
 
 import scala.collection.mutable
 import scala.collection.JavaConverters._
@@ -48,7 +47,6 @@ object internal extends Logging {
     dbEntity.setAttribute("locationUri", pathEntity)
     dbEntity.setAttribute("properties", dbDefinition.properties.asJava)
     dbEntity.setAttribute("owner", owner)
-    dbEntity.setAttribute("ownerType", "USER")
     Seq(dbEntity, pathEntity)
   }
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
@@ -36,6 +36,13 @@ object metadata {
 
   import external._
 
+  // "Referenceable" has one attribute:
+  // - "qualifiedName" (string)
+  // "DataSet" has inherited "Referenceable" and has three more attributes:
+  // - "name" (string)
+  // - "description" (string)
+  // - "owner" (string)
+
   // ========= DB type =========
   val DB_TYPE = AtlasTypeUtil.createClassTypeDef(
     DB_TYPE_STRING,
@@ -45,7 +52,6 @@ object metadata {
     AtlasTypeUtil.createUniqueRequiredAttrDef(
       "qualifiedName", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef(AtlasConstants.CLUSTER_NAME_ATTRIBUTE, new AtlasStringType),
-    AtlasTypeUtil.createOptionalAttrDef("description", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("locationUri", FS_PATH_TYPE_STRING),
     AtlasTypeUtil.createOptionalAttrDef(
       "properties", new AtlasMapType(new AtlasStringType, new AtlasStringType)))
@@ -109,7 +115,6 @@ object metadata {
       "partitionColumnNames", new AtlasArrayType(new AtlasStringType)),
     AtlasTypeUtil.createOptionalAttrDef(
       "bucketSpec", new AtlasMapType(new AtlasStringType, new AtlasStringType)),
-    AtlasTypeUtil.createOptionalAttrDef("owner", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("ownerType", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("createTime", new AtlasLongType),
     AtlasTypeUtil.createOptionalAttrDef(
@@ -153,7 +158,6 @@ object metadata {
     AtlasTypeUtil.createUniqueRequiredAttrDef(
       "qualifiedName", new AtlasStringType),
     AtlasTypeUtil.createRequiredAttrDef("directory", ML_DIRECTORY_TYPE_STRING),
-    AtlasTypeUtil.createOptionalAttrDef("description", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("extra", new AtlasStringType))
 
   // ========== ML model type ==========
@@ -165,7 +169,6 @@ object metadata {
     AtlasTypeUtil.createUniqueRequiredAttrDef(
       "qualifiedName", new AtlasStringType),
     AtlasTypeUtil.createRequiredAttrDef("directory", ML_DIRECTORY_TYPE_STRING),
-    AtlasTypeUtil.createOptionalAttrDef("description", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("extra", new AtlasStringType))
 
 }

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/AtlasExternalEntityUtilsSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/AtlasExternalEntityUtilsSuite.scala
@@ -20,12 +20,11 @@ package com.hortonworks.spark.atlas.types
 import java.nio.file.Files
 
 import scala.collection.JavaConverters._
-
 import org.apache.atlas.AtlasClient
 import org.apache.spark.sql.types._
 import org.scalatest.{FunSuite, Matchers}
-
 import com.hortonworks.spark.atlas.{AtlasClientConf, TestUtils, WithHiveSupport}
+import org.apache.atlas.model.instance.AtlasEntity
 
 class AtlasExternalEntityUtilsSuite extends FunSuite with Matchers with WithHiveSupport {
   import TestUtils._
@@ -51,7 +50,10 @@ class AtlasExternalEntityUtilsSuite extends FunSuite with Matchers with WithHive
     val dbEntity = dbEntities.head
     dbEntity.getTypeName should be (external.HIVE_DB_TYPE_STRING)
     dbEntity.getAttribute("name") should be ("db1")
-    dbEntity.getAttribute("location") should be (dbDefinition.locationUri.toString)
+    val locationUriEntity = dbEntity.getAttribute("locationUri").asInstanceOf[AtlasEntity]
+    locationUriEntity.getTypeName should be (external.HDFS_PATH_TYPE_STRING)
+    locationUriEntity.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
+      dbDefinition.locationUri.toString)
     dbEntity.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be ("db1@primary")
   }
 
@@ -62,7 +64,7 @@ class AtlasExternalEntityUtilsSuite extends FunSuite with Matchers with WithHive
 
     val sdEntity = sdEntities.head
     sdEntity.getTypeName should be (external.HIVE_STORAGEDESC_TYPE_STRING)
-    sdEntity.getAttribute("location") should be (null)
+    sdEntity.getAttribute("locationUri") should be (null)
     sdEntity.getAttribute("inputFormat") should be (null)
     sdEntity.getAttribute("outputFormat") should be (null)
     sdEntity.getAttribute("name") should be (null)
@@ -109,7 +111,7 @@ class AtlasExternalEntityUtilsSuite extends FunSuite with Matchers with WithHive
     tableEntity.getAttribute("name") should be ("tbl1")
     tableEntity.getAttribute("db") should be (dbEntity)
     tableEntity.getAttribute("sd") should be (sdEntity)
-    tableEntity.getAttribute("columns") should be (schemaEntities.asJava)
+    tableEntity.getAttribute("spark_schema") should be (schemaEntities.asJava)
     tableEntity.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
       "db1.tbl1@primary")
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fixes the mismatch between Hive catalog entities (attributes) and Spark catalog model definitions.
This patch also fixes the out of sync between Spark DB entity and its definition. (`ownerType`)

## How was this patch tested?

* Existing UT, and UT modified in AtlasExternalEntityUtilsSuite.scala
* Manually tested against Spark 2.4 & Atlas 1.1

The differences are shown with CTAS query:

`spark.sql("CREATE TABLE test_table_managed_sac_168_a SELECT * FROM test_table_sac_168_a")`

> before applying the patch

![test_table_managed_sac_168_before_patch_spark_table](https://user-images.githubusercontent.com/1317309/50831457-3a8b4400-138e-11e9-9695-0a3a74f65fe6.png)

![test_table_managed_sac_168_before_patch_spark_storagedesc](https://user-images.githubusercontent.com/1317309/50831467-40812500-138e-11e9-9bb4-67809e1771ae.png)

> after applying the patch

![test_table_managed_sac_168_after_patch_spark_table](https://user-images.githubusercontent.com/1317309/50831502-5abb0300-138e-11e9-9bc9-88d65989ddef.png)

![test_table_managed_sac_168_after_patch_spark_storagedesc](https://user-images.githubusercontent.com/1317309/50831506-5e4e8a00-138e-11e9-8e4a-2e33e6a31354.png)

Please take a look at some attributes `properties`, `locationUri`, and `serde`. I guess `spark_schema` will also show up after applying the patch when enabling column.

This closes #167 
