### PR TITLE
[SAC-170] Fix the old attribute name in spark table entity (storage -> sd)

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -121,7 +121,7 @@ object internal extends Logging {
     tblEntity.setAttribute("name", tableDefinition.identifier.table)
     tblEntity.setAttribute("db", dbEntities.head)
     tblEntity.setAttribute("tableType", tableDefinition.tableType.name)
-    tblEntity.setAttribute("storage", sdEntities.head)
+    tblEntity.setAttribute("sd", sdEntities.head)
     tblEntity.setAttribute("spark_schema", schemaEntities.asJava)
     tableDefinition.provider.foreach(tblEntity.setAttribute("provider", _))
     tblEntity.setAttribute("partitionColumnNames", tableDefinition.partitionColumnNames.asJava)

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/SparkAtlasEntityUtilsSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/SparkAtlasEntityUtilsSuite.scala
@@ -130,7 +130,7 @@ class SparkAtlasEntityUtilsSuite extends FunSuite with Matchers with BeforeAndAf
     tableEntity.getAttribute("db") should be (dbEntity)
     tableEntity.getAttribute("owner") should be (SparkUtils.currUser())
     tableEntity.getAttribute("ownerType") should be ("USER")
-    tableEntity.getAttribute("storage") should be (sdEntity)
+    tableEntity.getAttribute("sd") should be (sdEntity)
     tableEntity.getAttribute("spark_schema") should be (schemaEntities.asJava)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fixes the reference of old attribute name `storage` to new name `sd`. Also fixed relevant UT as well.

## How was this patch tested?

Existing UT, as well as modified UT.