### PR TITLE
[SAC-124][SQL][FOLLOW-UP] Make AtlasClient's createEntities thread-safe

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClient.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClient.scala
@@ -35,7 +35,7 @@ trait AtlasClient extends Logging {
 
   def findEntity(typeNang: String, qualifiedName: String): AtlasEntity
 
-  final def createEntities(entities: Seq[AtlasEntity]): Unit = {
+  final def createEntities(entities: Seq[AtlasEntity]): Unit = this.synchronized {
     if (entities.isEmpty) {
       return
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

I made a mistake at

https://github.com/hortonworks/spark-atlas-connector/commit/ee104f4c7f8773eba4519f7522d65d12048e0af7

This PR makes the client still thread-safe.

## How was this patch tested?

Manually tested

![screen shot 2019-01-08 at 2 27 40 pm](https://user-images.githubusercontent.com/6477701/50814620-4e668400-1355-11e9-9f1f-9d325579da6b.png)
