### PR TITLE
[SAC-174] Drop `spark_schema` attribute correctly when column is disabled

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
@@ -150,6 +150,7 @@ class SparkExecutionPlanProcessor(
           .map {
             case e if dbTypes.contains(e.getTypeName) =>
               e.removeAttribute("columns")
+              e.removeAttribute("spark_schema")
               e
             case e if e.getTypeName.equals(metadata.PROCESS_TYPE_STRING) =>
               Seq(e.getAttribute("inputs"), e.getAttribute("outputs")).foreach { list =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fixes the missing spot which `spark_schema` attribute is not dropped in spark table entity whereas column entities are dropped correctly, which raises error on Atlas side.

## How was this patch tested?

Manually tested against Spark 2.4 & Atlas 1.1. (This bug is not triggered without #172 though.)

This closes #174 