### PR TITLE
[WIP] Refactor CommandsHarvester to deduplicate pattern match

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -40,61 +40,30 @@ import com.hortonworks.spark.atlas.utils.{Logging, SparkUtils}
 object CommandsHarvester extends AtlasEntityUtils with Logging {
   override val conf: AtlasClientConf = new AtlasClientConf
 
+  val extractInputEntities = new InputEntities(this)
+  import extractInputEntities.toInputTablesEntities
+
   object InsertIntoHiveTableHarvester extends Harvester[InsertIntoHiveTable] {
     override def harvest(node: InsertIntoHiveTable, qd: QueryDetail): Seq[AtlasEntity] = {
-      // source tables entities
-      val tChildren = node.query.collectLeaves()
-      val inputsEntities = tChildren.map {
-        case r: HiveTableRelation => tableToEntities(r.tableMeta)
-        case v: View => tableToEntities(v.desc)
-        case l: LogicalRelation => tableToEntities(l.catalogTable.get)
-        case SHCEntities(shcEntities) => shcEntities
-        case HWCEntities(hwcEntities) => hwcEntities
+      val inputsEntities = node.query.collectLeaves().map {
+        case extractInputEntities(entities) => entities
         case e =>
           logWarn(s"Missing unknown leaf node: $e")
           Seq.empty
       }
 
-      // new table entity
       val outputEntities = tableToEntities(node.table)
-      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
-      val outputTableEntities = List(outputEntities.head)
-      val logMap = getPlanInfo(qd)
 
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputTablesEntities, outputEntities, logMap)
-      } else {
-        // create process entity
-        // Atlas doesn't support cycle here.
-        val cleanedOutput = cleanOutput(inputTablesEntities, outputTableEntities)
-        val pEntity = internal.etlProcessToEntity(
-          inputTablesEntities, cleanedOutput, logMap)
-        Seq(pEntity) ++ inputsEntities.flatten ++ cleanedOutput
-      }
+      harvestedEntities(inputsEntities, outputEntities, getPlanInfo(qd))
     }
   }
 
   object InsertIntoHadoopFsRelationHarvester extends Harvester[InsertIntoHadoopFsRelationCommand] {
     override def harvest(node: InsertIntoHadoopFsRelationCommand, qd: QueryDetail)
         : Seq[AtlasEntity] = {
-      // source tables/files entities
-      val tChildren = node.query.collectLeaves()
-      var isFiles = false
-      val inputsEntities = tChildren.map {
-        case r: HiveTableRelation => tableToEntities(r.tableMeta)
-        case v: View => tableToEntities(v.desc)
-        case l: LogicalRelation if l.catalogTable.isDefined =>
-          l.catalogTable.map(tableToEntities(_)).get
-        case SHCEntities(shcEntities) => shcEntities
-        case l: LogicalRelation =>
-          isFiles = true
-          l.relation match {
-            case r: FileRelation => r.inputFiles.map(external.pathToEntity).toSeq
-            case _ => Seq.empty
-          }
-        case HWCEntities(hwcEntities) => hwcEntities
-        case local: LocalRelation =>
+      val inputsEntities = node.query.collectLeaves().map {
+        case extractInputEntities(entities) => entities
+        case _: LocalRelation =>
           logInfo("Local Relation to store Spark ML pipelineModel")
           Seq.empty
         case e =>
@@ -102,23 +71,10 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
           Seq.empty
       }
 
-      val inputTablesEntities = if (isFiles) inputsEntities.flatten.toList
-      else inputsEntities.flatMap(_.headOption).toList
-
-      // new table/file entity
       val outputEntities = node.catalogTable.map(tableToEntities(_)).getOrElse(
         List(external.pathToEntity(node.outputPath.toUri.toString)))
-      val logMap = getPlanInfo(qd)
 
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputTablesEntities, outputEntities, logMap)
-      } else {
-        val cleanedOutput = cleanOutput(inputTablesEntities, outputEntities)
-        val processEntity = internal.etlProcessToEntity(
-          inputTablesEntities, cleanedOutput.headOption.toList, logMap)
-          Seq(processEntity) ++ inputsEntities.flatten ++ cleanedOutput
-        }
+      harvestedEntities(inputsEntities, outputEntities, getPlanInfo(qd))
     }
   }
 
@@ -126,40 +82,16 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
     override def harvest(
         node: CreateHiveTableAsSelectCommand,
         qd: QueryDetail): Seq[AtlasEntity] = {
-      // source tables entities
-      val tChildren = node.query.collectLeaves()
-      val inputsEntities = tChildren.map {
-        case r: HiveTableRelation => tableToEntities(r.tableMeta)
-        case v: View => tableToEntities(v.desc)
-        case l: LogicalRelation if l.relation.isInstanceOf[FileRelation] =>
-          l.catalogTable.map(tableToEntities(_)).getOrElse(
-            l.relation.asInstanceOf[FileRelation].inputFiles.map(external.pathToEntity).toSeq)
-        case _: OneRowRelation => Seq.empty
-        case SHCEntities(shcEntities) => shcEntities
-        case HWCEntities(hwcEntities) => hwcEntities
+      val inputsEntities = node.query.collectLeaves().map {
+        case extractInputEntities(entities) => entities
         case e =>
           logWarn(s"Missing unknown leaf node: $e")
           Seq.empty
       }
 
-      // new table entity
       val outputEntities = tableToEntities(node.tableDesc.copy(owner = SparkUtils.currUser()))
 
-      // create process entity
-      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
-      val outputTableEntities = List(outputEntities.head)
-      val logMap = getPlanInfo(qd)
-
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputTablesEntities, outputEntities, logMap)
-      } else {
-
-        // create process entity
-        val pEntity = internal.etlProcessToEntity(
-          inputTablesEntities, outputTableEntities, logMap)
-        Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
-      }
+      harvestedEntities(inputsEntities, outputEntities, getPlanInfo(qd))
     }
   }
 
@@ -168,53 +100,26 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
     override def harvest(
         node: CreateDataSourceTableAsSelectCommand,
         qd: QueryDetail): Seq[AtlasEntity] = {
-      val tChildren = node.query.collectLeaves()
-      val inputsEntities = tChildren.map {
-        case r: HiveTableRelation => tableToEntities(r.tableMeta)
-        case v: View => tableToEntities(v.desc)
-        case l: LogicalRelation if l.relation.isInstanceOf[FileRelation] =>
-          l.catalogTable.map(tableToEntities(_)).getOrElse(
-            l.relation.asInstanceOf[FileRelation].inputFiles.map(external.pathToEntity).toSeq)
-        case SHCEntities(shcEntities) => shcEntities
-        case HWCEntities(hwcEntities) => hwcEntities
+      val inputsEntities = node.query.collectLeaves().map {
+        case extractInputEntities(entities) => entities
         case e =>
           logWarn(s"Missing unknown leaf node: $e")
           Seq.empty
       }
+
       val outputEntities = tableToEntities(node.table)
-      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
-      val outputTableEntities = List(outputEntities.head)
-      val logMap = getPlanInfo(qd)
 
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputTablesEntities, outputEntities, logMap)
-      } else {
-
-        // create process entity
-        val pEntity = internal.etlProcessToEntity(
-          inputTablesEntities, outputTableEntities, logMap)
-        Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
-      }
+      harvestedEntities(inputsEntities, outputEntities, getPlanInfo(qd))
     }
   }
 
   object LoadDataHarvester extends Harvester[LoadDataCommand] {
     override def harvest(node: LoadDataCommand, qd: QueryDetail): Seq[AtlasEntity] = {
-      val pathEntity = external.pathToEntity(node.path)
+      val inputEntities = external.pathToEntity(node.path) :: Nil
+
       val outputEntities = prepareEntities(node.table)
-      val logMap = getPlanInfo(qd)
 
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(List(pathEntity), outputEntities, logMap)
-      } else {
-
-        // create process entity
-        val pEntity = internal.etlProcessToEntity(
-          List(pathEntity), List(outputEntities.head), logMap)
-        Seq(pEntity, pathEntity) ++ outputEntities
-      }
+      harvestedEntities(inputEntities :: Nil, outputEntities, getPlanInfo(qd))
     }
   }
 
@@ -224,47 +129,22 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
         throw new IllegalStateException("Location URI is illegally empty")
       }
 
-      val destEntity = external.pathToEntity(node.storage.locationUri.get.toString)
       val inputsEntities = qd.qe.sparkPlan.collectLeaves().map {
-        case h if h.getClass.getName == "org.apache.spark.sql.hive.execution.HiveTableScanExec" =>
-          Try {
-            val method = h.getClass.getMethod("relation")
-            method.setAccessible(true)
-            val relation = method.invoke(h).asInstanceOf[HiveTableRelation]
-            tableToEntities(relation.tableMeta)
-          }.getOrElse(Seq.empty)
-
-        case f: FileSourceScanExec =>
-          f.tableIdentifier.map(prepareEntities).getOrElse(
-            f.relation.location.inputFiles.map(external.pathToEntity).toSeq)
-        case SHCEntities(shcEntities) => shcEntities
-        case HWCEntities(hwcEntities) => hwcEntities
+        case extractInputEntities(entities) => entities
         case e =>
           logWarn(s"Missing unknown leaf node: $e")
           Seq.empty
       }
 
-      val inputs = inputsEntities.flatMap(_.headOption).toList
-      val logMap = getPlanInfo(qd)
+      val outputEntities = external.pathToEntity(node.storage.locationUri.get.toString)
 
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputs, List(destEntity), logMap)
-      } else {
-
-        // create process entity
-        val pEntity = internal.etlProcessToEntity(
-          inputs, List(destEntity), logMap)
-        Seq(pEntity, destEntity) ++ inputsEntities.flatten
-      }
+      harvestedEntities(inputsEntities, outputEntities :: Nil, getPlanInfo(qd))
     }
   }
 
   object CreateViewHarvester extends Harvester[CreateViewCommand] {
     override def harvest(node: CreateViewCommand, qd: QueryDetail): Seq[AtlasEntity] = {
-      // from table entities
-      val child = node.child.asInstanceOf[Project].child
-      val inputEntities = child match {
+      val inputEntities = node.child.asInstanceOf[Project].child match {
         case r: UnresolvedRelation => prepareEntities(r.tableIdentifier)
         case _: OneRowRelation => Seq.empty
         case n =>
@@ -272,25 +152,9 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
           Seq.empty
       }
 
-      // new view entities
-      val viewIdentifier = node.name
-      val outputEntities = prepareEntities(viewIdentifier)
+      val outputEntities = prepareEntities(node.name)
 
-      // create process entity
-      val inputTableEntity = inputEntities.headOption.toList
-      val outputTableEntity = List(outputEntities.head)
-      val logMap = getPlanInfo(qd)
-
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputTableEntity, outputTableEntity, logMap)
-      } else {
-
-        // create process entity
-        val pEntity = internal.etlProcessToEntity(
-          inputTableEntity, outputTableEntity, logMap)
-        Seq(pEntity) ++ inputEntities ++ outputEntities
-      }
+      harvestedEntities(inputEntities :: Nil, outputEntities, getPlanInfo(qd))
     }
   }
 
@@ -304,47 +168,58 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
 
   object SaveIntoDataSourceHarvester extends Harvester[SaveIntoDataSourceCommand] {
     override def harvest(node: SaveIntoDataSourceCommand, qd: QueryDetail): Seq[AtlasEntity] = {
-      // source table entity
-      val tChildren = node.query.collectLeaves()
-      val inputsEntities = tChildren.map {
-        case r: HiveTableRelation => tableToEntities(r.tableMeta)
-        case v: View => tableToEntities(v.desc)
-        case l: LogicalRelation if l.relation.isInstanceOf[FileRelation] =>
-          l.catalogTable.map(tableToEntities(_)).getOrElse(
-            l.relation.asInstanceOf[FileRelation].inputFiles.map(external.pathToEntity).toSeq)
-        case SHCEntities(shcEntities) => shcEntities
-        case HWCEntities(hwcEntities) => hwcEntities
+      val inputsEntities = node.query.collectLeaves().map {
+        case extractInputEntities(entities) => entities
         case e =>
           logWarn(s"Missing unknown leaf node: $e")
           Seq.empty
       }
 
-      // support Spark HBase Connector (destination table entity)
-      val outputEntities = SHCEntities.getSHCEntity(node.options)
+      val outputEntities = extractInputEntities.shcEntities.getSHCEntity(node.options)
 
-      // create process entity
-      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
-      val outputTableEntities = outputEntities.toList
-      val logMap = getPlanInfo(qd)
-
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputTablesEntities, outputTableEntities, logMap)
-      } else {
-
-        // create process entity
-        val pEntity = internal.etlProcessToEntity(
-          inputTablesEntities, outputTableEntities, logMap)
-        Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
-      }
+      harvestedEntities(inputsEntities, outputEntities, getPlanInfo(qd))
     }
   }
 
-  private def prepareEntities(tableIdentifier: TableIdentifier): Seq[AtlasEntity] = {
+  object HWCHarvester extends Harvester[WriteToDataSourceV2Exec] {
+    override def harvest(node: WriteToDataSourceV2Exec, qd: QueryDetail): Seq[AtlasEntity] = {
+      val inputsEntities = qd.qe.sparkPlan.collectLeaves().map {
+        case extractInputEntities(entities) => entities
+        case e =>
+          logWarn(s"Missing unknown leaf node: $e")
+          Seq.empty
+      }
+
+      val outputEntities = extractInputEntities.hwcEntities.getHWCEntity(node.writer)
+
+      harvestedEntities(inputsEntities, outputEntities, getPlanInfo(qd))
+    }
+  }
+
+  def prepareEntities(tableIdentifier: TableIdentifier): Seq[AtlasEntity] = {
     val tableName = tableIdentifier.table
     val dbName = tableIdentifier.database.getOrElse("default")
     val tableDef = SparkUtils.getExternalCatalog().getTable(dbName, tableName)
     tableToEntities(tableDef)
+  }
+
+  private def harvestedEntities(
+      inputsEntities: Seq[Seq[AtlasEntity]],
+      outputEntities: Seq[AtlasEntity],
+      logMap: Map[String, String]): Seq[AtlasEntity] = {
+    // Creates process entity
+    val inputTablesEntities = toInputTablesEntities(inputsEntities)
+    val outputTableEntities = outputEntities.toList
+
+    // ML related cached object
+    if (internal.cachedObjects.contains("model_uid")) {
+      internal.updateMLProcessToEntity(inputTablesEntities, outputTableEntities, logMap)
+    } else {
+      // Creates process entity
+      val pEntity = internal.etlProcessToEntity(
+        inputTablesEntities, outputTableEntities, logMap)
+      Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
+    }
   }
 
   private def getPlanInfo(qd: QueryDetail): Map[String, String] = {
@@ -354,179 +229,219 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       "details" -> qd.qe.toString(),
       "sparkPlanDescription" -> qd.qe.sparkPlan.toString())
   }
+}
 
-  object HWCHarvester extends Harvester[WriteToDataSourceV2Exec] {
-    override def harvest(node: WriteToDataSourceV2Exec, qd: QueryDetail): Seq[AtlasEntity] = {
-      // Source table entity
-      val inputsEntities = qd.qe.sparkPlan.collectLeaves().map {
-        case h if h.getClass.getName == "org.apache.spark.sql.hive.execution.HiveTableScanExec" =>
-          Try {
-            val method = h.getClass.getMethod("relation")
-            method.setAccessible(true)
-            val relation = method.invoke(h).asInstanceOf[HiveTableRelation]
-            tableToEntities(relation.tableMeta)
-          }.getOrElse(Seq.empty)
+class InputEntities(atlas: AtlasEntityUtils) {
+  val hiveTableEntities: HiveTableEntities = new HiveTableEntities(atlas)
+  val viewEntities: ViewEntities = new ViewEntities(atlas)
+  val hwcEntities: HWCEntities = new HWCEntities(atlas)
+  val shcEntities: SHCEntities = new SHCEntities(atlas)
+  // Other matters. `SparkTableEntities` should be the last.
+  val sparkTableEntities: SparkTableEntities = new SparkTableEntities(atlas)
 
-        case f: FileSourceScanExec =>
-          f.tableIdentifier.map(prepareEntities).getOrElse(
-            f.relation.location.inputFiles.map(external.pathToEntity).toSeq)
-        case HWCEntities(hwcEntities) => hwcEntities
-        case e =>
-          logWarn(s"Missing unknown leaf node: $e")
+  def unapply(plan: LogicalPlan): Option[Seq[AtlasEntity]] = plan match {
+    case hiveTableEntities(inputEntities) => Some(inputEntities)
+    case viewEntities(inputEntities) => Some(inputEntities)
+    case hwcEntities(inputEntities) => Some(inputEntities)
+    case shcEntities(inputEntities) => Some(inputEntities)
+    case sparkTableEntities(inputEntities) => Some(inputEntities)
+    case _ => None
+  }
+
+  def unapply(plan: SparkPlan): Option[Seq[AtlasEntity]] = plan match {
+    case hiveTableEntities(inputEntites) => Some(inputEntites)
+    case hwcEntities(inputEntites) => Some(inputEntites)
+    case shcEntities(inputEntites) => Some(inputEntites)
+    case sparkTableEntities(inputEntites) => Some(inputEntites)
+    case _ => None
+  }
+
+  def toInputTablesEntities(
+      inputsEntities: Seq[Seq[AtlasEntity]]): List[AtlasEntity] = {
+    inputsEntities.flatMap {
+      case entities if entities.forall(
+          entity => entity.getTypeName == external.FS_PATH_TYPE_STRING ||
+            entity.getTypeName == external.HDFS_PATH_TYPE_STRING) =>
+        // We will use all the paths as input entities.
+        entities
+      case entities => entities.headOption
+    }.toList
+  }
+}
+
+class HiveTableEntities(atlas: AtlasEntityUtils) {
+  def unapply(plan: LogicalPlan): Option[Seq[AtlasEntity]] = plan match {
+    case r: HiveTableRelation => Some(atlas.tableToEntities(r.tableMeta))
+    case _ => None
+  }
+
+  def unapply(plan: SparkPlan): Option[Seq[AtlasEntity]] = plan match {
+    case h if h.getClass.getName == "org.apache.spark.sql.hive.execution.HiveTableScanExec" =>
+      Some(Try {
+        val method = h.getClass.getMethod("relation")
+        method.setAccessible(true)
+        val relation = method.invoke(h).asInstanceOf[HiveTableRelation]
+        atlas.tableToEntities(relation.tableMeta)
+      }.getOrElse(Seq.empty))
+    case _ => None
+  }
+}
+
+class ViewEntities(atlas: AtlasEntityUtils) {
+  def unapply(plan: LogicalPlan): Option[Seq[AtlasEntity]] = plan match {
+    case v: View => Some(atlas.tableToEntities(v.desc))
+    case _ => None
+  }
+}
+
+class SparkTableEntities(atlas: AtlasEntityUtils) {
+  def unapply(plan: LogicalPlan): Option[Seq[AtlasEntity]] = plan match {
+    case l: LogicalRelation if l.relation.isInstanceOf[FileRelation] =>
+      Some(l.catalogTable.map(atlas.tableToEntities(_)).getOrElse(
+        l.relation.asInstanceOf[FileRelation].inputFiles.map(external.pathToEntity).toSeq))
+    case l: LogicalRelation =>
+      l.catalogTable.map(atlas.tableToEntities(_))
+    case _ => None
+  }
+
+  def unapply(plan: SparkPlan): Option[Seq[AtlasEntity]] = plan match {
+    case f: FileSourceScanExec =>
+      Some(f.tableIdentifier.map(CommandsHarvester.prepareEntities).getOrElse(
+        f.relation.location.inputFiles.map(external.pathToEntity).toSeq))
+    case _ => None
+  }
+}
+
+class HWCEntities(atlas: AtlasEntityUtils) extends Logging {
+
+  def unapply(plan: LogicalPlan): Option[Seq[AtlasEntity]] = plan match {
+    case ds: DataSourceV2Relation
+      if ds.source.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_READ_SOURCE) =>
+      Some(getHWCEntity(ds.options))
+    case _ => None
+  }
+
+  def unapply(plan: SparkPlan): Option[Seq[AtlasEntity]] = plan match {
+    case ds: DataSourceV2ScanExec
+      if ds.source.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_READ_SOURCE) =>
+      Some(getHWCEntity(ds.options))
+    case _ => None
+  }
+
+  def getHWCEntity(options: Map[String, String]): Seq[AtlasEntity] = {
+    if (options.contains("query")) {
+      val sql = options("query")
+      // HACK ALERT! Currently SAC and HWC only know the query that has to be pushed down
+      // to Hive side so here we don't know which tables are to be proceeded. To work around,
+      // we use Spark's parser driver to identify tables. Once we know the table
+      // identifiers by this, it looks up Hive entities to find Hive tables out.
+      val parsedPlan = org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parsePlan(sql)
+      parsedPlan.collectLeaves().flatMap {
+        case r: UnresolvedRelation =>
+          val db = r.tableIdentifier.database.getOrElse(
+            options.getOrElse("default.db", "default"))
+          val tableName = r.tableIdentifier.table
+          external.hwcTableToEntities(db, tableName, atlas.clusterName)
+        case _: OneRowRelation => Seq.empty
+        case n =>
+          logWarn(s"Unknown leaf node: $n")
           Seq.empty
       }
-
-      // Supports Spark HWC (destination table entity)
-      val outputEntities = HWCEntities.getHWCEntity(node.writer)
-
-      // Creates process entity
-      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
-      val outputTableEntities = outputEntities.toList
-      val logMap = getPlanInfo(qd)
-
-      // ML related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputTablesEntities, outputTableEntities, logMap)
-      } else {
-        // Creates process entity
-        val pEntity = internal.etlProcessToEntity(
-          inputTablesEntities, outputTableEntities, logMap)
-        Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
-      }
+    } else {
+      val (db, tableName) = getDbTableNames(
+        options.getOrElse("default.db", "default"), options.getOrElse("table", ""))
+      external.hwcTableToEntities(db, tableName, atlas.clusterName)
     }
   }
 
-  object HWCEntities extends Logging {
+  def getHWCEntity(r: DataSourceWriter): Seq[AtlasEntity] = r match {
+    case _ if r.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_WRITE) =>
+      val f = r.getClass.getDeclaredField("options")
+      f.setAccessible(true)
+      val options = f.get(r).asInstanceOf[java.util.Map[String, String]]
+      val (db, tableName) = getDbTableNames(
+        options.getOrDefault("default.db", "default"), options.getOrDefault("table", ""))
+      external.hwcTableToEntities(db, tableName, atlas.clusterName)
 
-    def unapply(plan: LogicalPlan): Option[Seq[AtlasEntity]] = plan match {
-      case ds: DataSourceV2Relation
-          if ds.source.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_READ_SOURCE) =>
-        Some(getHWCEntity(ds.options))
-      case _ => None
-    }
+    case _ if r.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_STREAM_WRITE) =>
+      val dbField = r.getClass.getDeclaredField("db")
+      dbField.setAccessible(true)
+      val db = dbField.get(r).asInstanceOf[String]
 
-    def unapply(plan: SparkPlan): Option[Seq[AtlasEntity]] = plan match {
-      case ds: DataSourceV2ScanExec
-          if ds.source.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_READ_SOURCE) =>
-        Some(getHWCEntity(ds.options))
-      case _ => None
-    }
+      val tableField = r.getClass.getDeclaredField("table")
+      tableField.setAccessible(true)
+      val table = tableField.get(r).asInstanceOf[String]
 
-    def getHWCEntity(options: Map[String, String]): Seq[AtlasEntity] = {
-      if (options.contains("query")) {
-        val sql = options("query")
-        // HACK ALERT! Currently SAC and HWC only know the query that has to be pushed down
-        // to Hive side so here we don't know which tables are to be proceeded. To work around,
-        // we use Spark's parser driver to identify tables. Once we know the table
-        // identifiers by this, it looks up Hive entities to find Hive tables out.
-        val parsedPlan = org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parsePlan(sql)
-        parsedPlan.collectLeaves().flatMap {
-          case r: UnresolvedRelation =>
-            val db = r.tableIdentifier.database.getOrElse(
-              options.getOrElse("default.db", "default"))
-            val tableName = r.tableIdentifier.table
-            external.hwcTableToEntities(db, tableName, clusterName)
-          case _: OneRowRelation => Seq.empty
-          case n =>
-            logWarn(s"Unknown leaf node: $n")
-            Seq.empty
-        }
-      } else {
-        val (db, tableName) = getDbTableNames(
-          options.getOrElse("default.db", "default"), options.getOrElse("table", ""))
-        external.hwcTableToEntities(db, tableName, clusterName)
-      }
-    }
+      external.hwcTableToEntities(db, table, atlas.clusterName)
 
-    def getHWCEntity(r: DataSourceWriter): Seq[AtlasEntity] = r match {
-      case _ if r.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_WRITE) =>
-        val f = r.getClass.getDeclaredField("options")
-        f.setAccessible(true)
-        val options = f.get(r).asInstanceOf[java.util.Map[String, String]]
-        val (db, tableName) = getDbTableNames(
-          options.getOrDefault("default.db", "default"), options.getOrDefault("table", ""))
-        external.hwcTableToEntities(db, tableName, clusterName)
+    case _ if r.getClass.getCanonicalName.endsWith(HWCSupport.STREAM_WRITE) =>
+      val dbField = r.getClass.getDeclaredField("db")
+      dbField.setAccessible(true)
+      val db = dbField.get(r).asInstanceOf[String]
 
-      case _ if r.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_STREAM_WRITE) =>
-        val dbField = r.getClass.getDeclaredField("db")
-        dbField.setAccessible(true)
-        val db = dbField.get(r).asInstanceOf[String]
+      val tableField = r.getClass.getDeclaredField("table")
+      tableField.setAccessible(true)
+      val table = tableField.get(r).asInstanceOf[String]
 
-        val tableField = r.getClass.getDeclaredField("table")
-        tableField.setAccessible(true)
-        val table = tableField.get(r).asInstanceOf[String]
+      external.hwcTableToEntities(db, table, atlas.clusterName)
 
-        external.hwcTableToEntities(db, table, clusterName)
-
-      case _ if r.getClass.getCanonicalName.endsWith(HWCSupport.STREAM_WRITE) =>
-        val dbField = r.getClass.getDeclaredField("db")
-        dbField.setAccessible(true)
-        val db = dbField.get(r).asInstanceOf[String]
-
-        val tableField = r.getClass.getDeclaredField("table")
-        tableField.setAccessible(true)
-        val table = tableField.get(r).asInstanceOf[String]
-
-        external.hwcTableToEntities(db, table, clusterName)
-
-      case _ => Seq.empty
-    }
-
-    // This logic was ported from HWC's `SchemaUtil.getDbTableNames`
-    private def getDbTableNames(db: String, nameStr: String): (String, String) = {
-      val nameParts = nameStr.split("\\.")
-      if (nameParts.length == 1) {
-        // hive.table(<unqualified_tableName>) so fill in db from default session db
-        (db, nameStr)
-      }
-      else if (nameParts.length == 2) {
-        // hive.table(<qualified_tableName>) so use the provided db
-        (nameParts(0), nameParts(1))
-      } else {
-        throw new IllegalArgumentException(
-          "Table name should be specified as either <table> or <db.table>")
-      }
-    }
+    case _ => Seq.empty
   }
 
-  object SHCEntities {
-    private val SHC_RELATION_CLASS_NAME =
-      "org.apache.spark.sql.execution.datasources.hbase.HBaseRelation"
-
-    def unapply(plan: LogicalPlan): Option[Seq[AtlasEntity]] = plan match {
-      case l: LogicalRelation
-        if l.relation.getClass.getCanonicalName.endsWith(SHC_RELATION_CLASS_NAME) =>
-        val baseRelation = l.relation.asInstanceOf[BaseRelation]
-        val options = baseRelation.getClass.getMethod("parameters")
-          .invoke(baseRelation).asInstanceOf[Map[String, String]]
-        Some(getSHCEntity(options))
-      case _ => None
+  // This logic was ported from HWC's `SchemaUtil.getDbTableNames`
+  private def getDbTableNames(db: String, nameStr: String): (String, String) = {
+    val nameParts = nameStr.split("\\.")
+    if (nameParts.length == 1) {
+      // hive.table(<unqualified_tableName>) so fill in db from default session db
+      (db, nameStr)
     }
-
-    def unapply(plan: SparkPlan): Option[Seq[AtlasEntity]] = plan match {
-      case r: RowDataSourceScanExec
-        if r.relation.getClass.getCanonicalName.endsWith(SHC_RELATION_CLASS_NAME) =>
-        val baseRelation = r.relation.asInstanceOf[BaseRelation]
-        val options = baseRelation.getClass.getMethod("parameters")
-          .invoke(baseRelation).asInstanceOf[Map[String, String]]
-        Some(getSHCEntity(options))
-      case _ => None
+    else if (nameParts.length == 2) {
+      // hive.table(<qualified_tableName>) so use the provided db
+      (nameParts(0), nameParts(1))
+    } else {
+      throw new IllegalArgumentException(
+        "Table name should be specified as either <table> or <db.table>")
     }
+  }
+}
 
-    def getSHCEntity(options: Map[String, String]): Seq[AtlasEntity] = {
-      if (options.getOrElse("catalog", "") != "") {
-        val catalog = options("catalog")
-        val cluster = options.getOrElse(AtlasClientConf.CLUSTER_NAME.key, clusterName)
-        val jObj = parse(catalog).asInstanceOf[JObject]
-        val map = jObj.values
-        val tableMeta = map("table").asInstanceOf[Map[String, _]]
-        // `asInstanceOf` is required. Otherwise, it fails compilation.
-        val nSpace = tableMeta.getOrElse("namespace", "default").asInstanceOf[String]
-        val tName = tableMeta("name").asInstanceOf[String]
-        external.hbaseTableToEntity(cluster, tName, nSpace)
-      } else {
-        Seq.empty[AtlasEntity]
-      }
+class SHCEntities(atlas: AtlasEntityUtils) {
+  private val SHC_RELATION_CLASS_NAME =
+    "org.apache.spark.sql.execution.datasources.hbase.HBaseRelation"
+
+  def unapply(plan: LogicalPlan): Option[Seq[AtlasEntity]] = plan match {
+    case l: LogicalRelation
+      if l.relation.getClass.getCanonicalName.endsWith(SHC_RELATION_CLASS_NAME) =>
+      val baseRelation = l.relation.asInstanceOf[BaseRelation]
+      val options = baseRelation.getClass.getMethod("parameters")
+        .invoke(baseRelation).asInstanceOf[Map[String, String]]
+      Some(getSHCEntity(options))
+    case _ => None
+  }
+
+  def unapply(plan: SparkPlan): Option[Seq[AtlasEntity]] = plan match {
+    case r: RowDataSourceScanExec
+      if r.relation.getClass.getCanonicalName.endsWith(SHC_RELATION_CLASS_NAME) =>
+      val baseRelation = r.relation.asInstanceOf[BaseRelation]
+      val options = baseRelation.getClass.getMethod("parameters")
+        .invoke(baseRelation).asInstanceOf[Map[String, String]]
+      Some(getSHCEntity(options))
+    case _ => None
+  }
+
+  def getSHCEntity(options: Map[String, String]): Seq[AtlasEntity] = {
+    if (options.getOrElse("catalog", "") != "") {
+      val catalog = options("catalog")
+      val cluster = options.getOrElse(AtlasClientConf.CLUSTER_NAME.key, atlas.clusterName)
+      val jObj = parse(catalog).asInstanceOf[JObject]
+      val map = jObj.values
+      val tableMeta = map("table").asInstanceOf[Map[String, _]]
+      // `asInstanceOf` is required. Otherwise, it fails compilation.
+      val nSpace = tableMeta.getOrElse("namespace", "default").asInstanceOf[String]
+      val tName = tableMeta("name").asInstanceOf[String]
+      external.hbaseTableToEntity(cluster, tName, nSpace)
+    } else {
+      Seq.empty[AtlasEntity]
     }
   }
 }

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/HWCStreamingHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/HWCStreamingHarvester.scala
@@ -17,7 +17,6 @@
 
 package com.hortonworks.spark.atlas.sql
 
-import com.hortonworks.spark.atlas.sql.CommandsHarvester.HWCEntities
 import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec
 import org.apache.spark.sql.kafka010.atlas.KafkaHarvester
@@ -29,7 +28,8 @@ object HWCStreamingHarvester extends Harvester[WriteToDataSourceV2Exec] {
     val sourceTopics = KafkaHarvester.extractSourceTopics(node)
     val inputsEntities: Seq[AtlasEntity] = KafkaHarvester.extractInputEntities(sourceTopics)
 
-    val outputEntities = HWCEntities.getHWCEntity(node.writer)
+    val outputEntities = CommandsHarvester
+      .extractInputEntities.hwcEntities.getHWCEntity(node.writer)
     val logMap = KafkaHarvester.makeLogMap(sourceTopics, None, qd)
 
     val updatedLogMap = logMap ++ Map(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, a lot of codes, in particular, input pattern match and output entities are duplicated. This PR proposes to deduplicate all of them. Namely:

1. For instance, the pattern below is duplicated too often.

```scala
      val inputsEntities = tChildren.map {
        case r: HiveTableRelation => tableToEntities(r.tableMeta)
        case v: View => tableToEntities(v.desc)
        case l: LogicalRelation if l.catalogTable.isDefined =>
          l.catalogTable.map(tableToEntities(_)).get
        case l: LogicalRelation =>
          isFiles = true
          l.relation match {
            case r: FileRelation => r.inputFiles.map(external.pathToEntity).toSeq
            case _ => Seq.empty
          }
        case HWCEntities(hwcEntities) => hwcEntities
    ...
```

This PR changes above code as below:

```scala
class InputEntities(atlas: AtlasEntityUtils) {
  val hiveTableEntities: HiveTableEntities = new HiveTableEntities(atlas)
  val viewEntities: ViewEntities = new ViewEntities(atlas)
  val hwcEntities: HWCEntities = new HWCEntities(atlas)
  val shcEntities: SHCEntities = new SHCEntities(atlas)
...

class HiveTableEntities
  //  case r: HiveTableRelation => tableToEntities(r.tableMeta)

class ViewEntities
  //  case v: View => tableToEntities(v.desc)

class HWCEntities
  //  case HWCEntities(hwcEntities) => hwcEntities

class SHCEntities
  //  case SHCEntities(shcEntities) => shcEntities

class SparkTableEntities
  // case l: LogicalRelation if l.catalogTable.isDefined =>
  // ...
  // case l: LogicalRelation =>
  // ...
```

and call `InputEntities` instead for duplicated places.

2. output creation patterns are too much duplicated.

```scala
      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
      val outputTableEntities = List(outputEntities.head)
      val logMap = getPlanInfo(qd)

      // ml related cached object
      if (internal.cachedObjects.contains("model_uid")) {
        internal.updateMLProcessToEntity(inputTablesEntities, outputEntities, logMap)
      } else {
        // create process entity
        // Atlas doesn't support cycle here.
        val cleanedOutput = cleanOutput(inputTablesEntities, outputTableEntities)
        val pEntity = internal.etlProcessToEntity(
          inputTablesEntities, cleanedOutput, logMap)
        Seq(pEntity) ++ inputsEntities.flatten ++ cleanedOutput
      }
```

This PR changes above code as below:

```scala
  private def harvestedEntities(
      inputsEntities: Seq[Seq[AtlasEntity]],
      outputEntities: Seq[AtlasEntity],
      logMap: Map[String, String]): Seq[AtlasEntity] = {
    // Creates process entity
    val inputTablesEntities = toInputTablesEntities(inputsEntities)
    val outputTableEntities = outputEntities.toList

    // ML related cached object
    if (internal.cachedObjects.contains("model_uid")) {
      internal.updateMLProcessToEntity(inputTablesEntities, outputTableEntities, logMap)
    } else {
      // Creates process entity
      val pEntity = internal.etlProcessToEntity(
        inputTablesEntities, outputTableEntities, logMap)
      Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
    }
  }
```

## How was this patch tested?

TODO
