### PR TITLE
[SAC-176][SQL][FOLLOW-UP] Harvest SHCEntities when HWC is output as well

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -370,6 +370,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
         case f: FileSourceScanExec =>
           f.tableIdentifier.map(prepareEntities).getOrElse(
             f.relation.location.inputFiles.map(external.pathToEntity).toSeq)
+        case SHCEntities(shcEntities) => shcEntities
         case HWCEntities(hwcEntities) => hwcEntities
         case e =>
           logWarn(s"Missing unknown leaf node: $e")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Followup of https://github.com/hortonworks-spark/spark-atlas-connector/pull/177. When HWC is output, it is also possible for SHC to be its input.

## How was this patch tested?

Manual
