### PR TITLE
[SAC-184][SQL] Record Kafka topic entity correctly when saving DF to Kafka via DF.save()

### DIFF
--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/BaseResourceIT.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/BaseResourceIT.scala
@@ -37,8 +37,8 @@ abstract class BaseResourceIT extends FunSuite with BeforeAndAfterAll {
     super.beforeAll()
 
 
-    //set high timeouts so that tests do not fail due to read timeouts while you
-    //are stepping through the code in a debugger
+    // set high timeouts so that tests do not fail due to read timeouts while you
+    // are stepping through the code in a debugger
     atlasClientConf.set("atlas.client.readTimeoutMSecs", "100000000")
     atlasClientConf.set("atlas.client.connectTimeoutMSecs", "100000000")
     atlasUrls = Array(atlasClientConf.get(AtlasClientConf.ATLAS_REST_ENDPOINT))

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
@@ -346,7 +346,8 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
   }
 
   test("INSERT INTO MULTIPLE TABLES FROM MULTIPLE TABLES") {
-    val qe = sparkSession.sql(s"WITH view1 AS (SELECT * FROM $inputTable1, $inputTable2, $inputTable3 " +
+    val qe = sparkSession.sql(s"WITH view1 AS " +
+      s"(SELECT * FROM $inputTable1, $inputTable2, $inputTable3 " +
       s"where $inputTable1.a = $inputTable2.b AND $inputTable1.a = $inputTable3.c) " +
       s"FROM view1 INSERT INTO TABLE $outputTable1 SELECT view1.a " +
       s"INSERT INTO TABLE $outputTable2 SELECT view1.b " +

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForBatchQuerySuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForBatchQuerySuite.scala
@@ -21,16 +21,24 @@ import java.io.{BufferedWriter, File, FileWriter}
 import java.nio.file.{Files, Path}
 import java.util.Locale
 
-import com.hortonworks.spark.atlas.sql.testhelper.{AtlasQueryExecutionListener, CreateEntitiesTrackingAtlasClient, DirectProcessSparkExecutionPlanProcessor}
+import com.hortonworks.spark.atlas.sql.testhelper.{AtlasQueryExecutionListener, CreateEntitiesTrackingAtlasClient, DirectProcessSparkExecutionPlanProcessor, KafkaTopicEntityValidator}
 import com.hortonworks.spark.atlas.types.{external, metadata}
 import com.hortonworks.spark.atlas.utils.SparkUtils
 import com.hortonworks.spark.atlas.AtlasClientConf
+import com.hortonworks.spark.atlas.sql.streaming.KafkaTopicInformation
+
 import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.commons.io.{FileUtils, IOUtils}
+import org.apache.spark.sql.kafka010.KafkaTestUtils
 import org.apache.spark.sql.streaming.StreamTest
 
-class SparkExecutionPlanProcessorForBatchQuerySuite extends StreamTest {
+class SparkExecutionPlanProcessorForBatchQuerySuite
+  extends StreamTest
+  with KafkaTopicEntityValidator {
   import com.hortonworks.spark.atlas.sql.testhelper.AtlasEntityReadHelper._
+
+  val brokerProps: Map[String, Object] = Map[String, Object]()
+  var kafkaTestUtils: KafkaTestUtils = _
 
   val atlasClientConf: AtlasClientConf = new AtlasClientConf()
     .set(AtlasClientConf.CHECK_MODEL_IN_START.key, "false")
@@ -39,12 +47,18 @@ class SparkExecutionPlanProcessorForBatchQuerySuite extends StreamTest {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
+    kafkaTestUtils = new KafkaTestUtils(brokerProps)
+    kafkaTestUtils.setup()
     atlasClient = new CreateEntitiesTrackingAtlasClient()
     testHelperQueryListener.clear()
     spark.listenerManager.register(testHelperQueryListener)
   }
 
   override def afterAll(): Unit = {
+    if (kafkaTestUtils != null) {
+      kafkaTestUtils.teardown()
+      kafkaTestUtils = null
+    }
     atlasClient = null
     spark.listenerManager.unregister(testHelperQueryListener)
     super.afterAll()
@@ -178,6 +192,78 @@ class SparkExecutionPlanProcessorForBatchQuerySuite extends StreamTest {
     assert(getAtlasEntityAttribute(storageEntity, "locationUri") === inputFsEntity)
   }
 
+  test("Save Spark table to Kafka via df.save()") {
+    val planProcessor = new DirectProcessSparkExecutionPlanProcessor(atlasClient, atlasClientConf)
+
+    val rand = new scala.util.Random()
+    val inputTableName = "test_spark_table_" + rand.nextInt(1000000000)
+    val outputTopicName = "test_spark_topic_" + rand.nextInt(1000000000)
+
+    val csvContent = Seq("a,1", "b,2", "c,3", "d,4").mkString("\n")
+    val tempFile: Path = writeCSVtextToTempFile(csvContent)
+
+    val df = spark.read.csv(tempFile.toAbsolutePath.toString)
+    df.write.saveAsTable(inputTableName)
+
+    // we don't want to check above queries, so reset the entities in listener
+    testHelperQueryListener.clear()
+
+    val customClusterName = "customCluster"
+
+    spark
+      .sql(s"select * from $inputTableName")
+      .selectExpr("cast(_c0 as String) AS value")
+      .write
+      .format("kafka")
+      .option("kafka.bootstrap.servers", kafkaTestUtils.brokerAddress)
+      .option("topic", outputTopicName)
+      .option("kafka." + AtlasClientConf.CLUSTER_NAME.key, customClusterName)
+      .save()
+
+    val queryDetail = testHelperQueryListener.queryDetails.last
+    planProcessor.process(queryDetail)
+
+    val entities = atlasClient.createdEntities
+
+    // We already have validations for table-relevant entities in other UTs,
+    // so minimize validation here.
+
+    val tableEntity: AtlasEntity = getOnlyOneEntity(entities, metadata.TABLE_TYPE_STRING)
+    assertTableEntity(tableEntity, inputTableName)
+    assertSchemaEntities(tableEntity, entities)
+
+    // kafka topic
+    val outputKafkaEntity = getOnlyOneEntity(entities, external.KAFKA_TOPIC_STRING)
+    val expectedTopics = Seq(
+      KafkaTopicInformation(outputTopicName, Some(customClusterName))
+    )
+    assertEntitiesKafkaTopicType(expectedTopics, entities.toSet)
+
+    // check for 'spark_process'
+    val processEntity = getOnlyOneEntity(entities, metadata.PROCESS_TYPE_STRING)
+
+    val inputs = getSeqAtlasEntityAttribute(processEntity, "inputs")
+    val outputs = getSeqAtlasEntityAttribute(processEntity, "outputs")
+
+    val input = getOnlyOneEntity(inputs, metadata.TABLE_TYPE_STRING)
+    val output = getOnlyOneEntity(outputs, external.KAFKA_TOPIC_STRING)
+
+    // input/output in 'spark_process' should be same as outer entities
+    assert(input === tableEntity)
+    assert(output === outputKafkaEntity)
+
+    val expectedMap = Map(
+      "executionId" -> queryDetail.executionId.toString,
+      "remoteUser" -> SparkUtils.currSessionUser(queryDetail.qe),
+      "executionTime" -> queryDetail.executionTime.toString,
+      "details" -> queryDetail.qe.toString()
+    )
+
+    expectedMap.foreach { case (key, value) =>
+      assert(processEntity.getAttribute(key) === value)
+    }
+  }
+
   private def writeCSVtextToTempFile(csvContent: String) = {
     val tempFile = Files.createTempFile("spark-atlas-connector-csv-temp", ".csv")
 
@@ -260,7 +346,8 @@ class SparkExecutionPlanProcessorForBatchQuerySuite extends StreamTest {
       "file://" + sourcePath)
   }
 
-  private def assertStorageDefinitionEntity(sdEntity: AtlasEntity, tableEntity: AtlasEntity): Unit = {
+  private def assertStorageDefinitionEntity(sdEntity: AtlasEntity, tableEntity: AtlasEntity)
+    : Unit = {
     val tableQualifiedName = getStringAttribute(tableEntity, "qualifiedName")
     val storageQualifiedName = tableQualifiedName + ".storageFormat"
     assert(getStringAttribute(sdEntity, "qualifiedName") === storageQualifiedName)

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
@@ -19,19 +19,20 @@ package com.hortonworks.spark.atlas.sql
 
 import java.nio.file.Files
 
-import org.apache.atlas.model.instance.AtlasEntity
-import org.apache.spark.sql.kafka010.KafkaTestUtils
-import org.apache.spark.sql.streaming.{StreamTest, StreamingQuery}
-
-import com.hortonworks.spark.atlas.sql.testhelper.{AtlasQueryExecutionListener, CreateEntitiesTrackingAtlasClient, DirectProcessSparkExecutionPlanProcessor}
+import com.hortonworks.spark.atlas.sql.testhelper.{AtlasQueryExecutionListener, CreateEntitiesTrackingAtlasClient, DirectProcessSparkExecutionPlanProcessor, KafkaTopicEntityValidator}
 import com.hortonworks.spark.atlas.types.external.KAFKA_TOPIC_STRING
 import com.hortonworks.spark.atlas.types.metadata
 import com.hortonworks.spark.atlas.utils.SparkUtils
 import com.hortonworks.spark.atlas.AtlasClientConf
 import com.hortonworks.spark.atlas.sql.streaming.KafkaTopicInformation
 
+import org.apache.atlas.model.instance.AtlasEntity
+import org.apache.spark.sql.kafka010.KafkaTestUtils
+import org.apache.spark.sql.streaming.{StreamTest, StreamingQuery}
 
-class SparkExecutionPlanProcessorForStreamingQuerySuite extends StreamTest {
+class SparkExecutionPlanProcessorForStreamingQuerySuite
+  extends StreamTest
+  with KafkaTopicEntityValidator {
   import com.hortonworks.spark.atlas.sql.testhelper.AtlasEntityReadHelper._
 
   val brokerProps: Map[String, Object] = Map[String, Object]()
@@ -163,27 +164,6 @@ class SparkExecutionPlanProcessorForStreamingQuerySuite extends StreamTest {
       query.processAllAvailable()
       assert(listener.queryDetails.nonEmpty)
     }
-  }
-
-  private def assertEntitiesKafkaTopicType(topics: Seq[KafkaTopicInformation],
-                                           entities: Set[AtlasEntity]): Unit = {
-    val kafkaTopicEntities = listAtlasEntitiesAsType(entities.toSeq, KAFKA_TOPIC_STRING)
-    assert(kafkaTopicEntities.size === topics.size)
-
-    val expectedTopicNames = topics.map(_.topicName).toSet
-    val expectedClusterNames = topics.map(_.clusterName.getOrElse("primary")).toSet
-    val expectedQualifiedNames = topics.map { ti =>
-      KafkaTopicInformation.getQualifiedName(ti, "primary")
-    }.toSet
-
-    assert(kafkaTopicEntities.map(_.getAttribute("name").toString()).toSet === expectedTopicNames)
-    assert(kafkaTopicEntities.map(_.getAttribute("topic").toString()).toSet ===
-      expectedTopicNames)
-    assert(kafkaTopicEntities.map(getStringAttribute(_, "uri")).toSet === expectedTopicNames)
-    assert(kafkaTopicEntities.map(getStringAttribute(_, "clusterName")).toSet ===
-      expectedClusterNames)
-    assert(kafkaTopicEntities.map(getStringAttribute(_, "qualifiedName")).toSet ===
-      expectedQualifiedNames)
   }
 
   private def assertEntitySparkProcessType(

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/KafkaTopicEntityValidator.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/KafkaTopicEntityValidator.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql.testhelper
+
+import org.scalatest.FunSuite
+
+import com.hortonworks.spark.atlas.sql.streaming.KafkaTopicInformation
+import com.hortonworks.spark.atlas.sql.testhelper.AtlasEntityReadHelper.{getStringAttribute, listAtlasEntitiesAsType}
+import com.hortonworks.spark.atlas.types.external.KAFKA_TOPIC_STRING
+
+import org.apache.atlas.model.instance.AtlasEntity
+
+trait KafkaTopicEntityValidator extends FunSuite {
+
+  def assertEntitiesKafkaTopicType(
+      topics: Seq[KafkaTopicInformation],
+      entities: Set[AtlasEntity]): Unit = {
+    val kafkaTopicEntities = listAtlasEntitiesAsType(entities.toSeq, KAFKA_TOPIC_STRING)
+    assert(kafkaTopicEntities.size === topics.size)
+
+    val expectedTopicNames = topics.map(_.topicName).toSet
+    val expectedClusterNames = topics.map(_.clusterName.getOrElse("primary")).toSet
+    val expectedQualifiedNames = topics.map { ti =>
+      KafkaTopicInformation.getQualifiedName(ti, "primary")
+    }.toSet
+
+    assert(kafkaTopicEntities.map(_.getAttribute("name").toString()).toSet === expectedTopicNames)
+    assert(kafkaTopicEntities.map(_.getAttribute("topic").toString()).toSet ===
+      expectedTopicNames)
+    assert(kafkaTopicEntities.map(getStringAttribute(_, "uri")).toSet === expectedTopicNames)
+    assert(kafkaTopicEntities.map(getStringAttribute(_, "clusterName")).toSet ===
+      expectedClusterNames)
+    assert(kafkaTopicEntities.map(getStringAttribute(_, "qualifiedName")).toSet ===
+      expectedQualifiedNames)
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch addresses the bug which Kafka topic is not recorded when saving DF to Kafka via DF.save().
This patch also refactors the code regarding testing Kafka entity a bit to reduce redundant lines.

## How was this patch tested?

Added UT. Also manually tested with Spark 2.4 & Atlas 1.1.

```
// prepare
spark.sql("create table default.s4_spark_t1_1658400062_a (col1 int)")
spark.sql("insert into s4_spark_t1_1658400062_a values(1)")

// test query
spark.sql("select * from s4_spark_t1_1658400062_a").selectExpr("cast(col1 as String) value").write.format("kafka").option("kafka.bootstrap.servers", "localhost:9027").option("topic", "test_spark_topic_WIP_BUG_116565").option("kafka.atlas.cluster.name", "custom_cluster").save()
```

![screen shot 2019-01-09 at 7 30 38 pm](https://user-images.githubusercontent.com/1317309/50894886-cdd48000-1447-11e9-9560-1b457e29377c.png)
![screen shot 2019-01-09 at 7 30 48 pm](https://user-images.githubusercontent.com/1317309/50894888-cdd48000-1447-11e9-98c9-4aabe5055940.png)
![screen shot 2019-01-09 at 7 31 01 pm](https://user-images.githubusercontent.com/1317309/50894890-ce6d1680-1447-11e9-824c-e3d78c6fe572.png)
![screen shot 2019-01-09 at 7 31 17 pm](https://user-images.githubusercontent.com/1317309/50894891-ce6d1680-1447-11e9-96ab-f6772324e69a.png)

This closes #184 