### PR TITLE
[SAC-184][SQL] Record Kafka topic entity correctly when saving DF to Kafka via DF.save()

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -21,6 +21,7 @@ import org.json4s.JsonAST.JObject
 import org.json4s.jackson.JsonMethods._
 
 import scala.util.Try
+
 import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
@@ -33,7 +34,9 @@ import org.apache.spark.sql.hive.execution._
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanExec, WriteToDataSourceV2Exec}
 import org.apache.spark.sql.sources.v2.writer.DataSourceWriter
+
 import com.hortonworks.spark.atlas.AtlasClientConf
+import com.hortonworks.spark.atlas.sql.streaming.KafkaTopicInformation
 import com.hortonworks.spark.atlas.types.{AtlasEntityUtils, external, internal}
 import com.hortonworks.spark.atlas.utils.{Logging, SparkUtils}
 
@@ -301,7 +304,6 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
     }
   }
 
-
   object SaveIntoDataSourceHarvester extends Harvester[SaveIntoDataSourceCommand] {
     override def harvest(node: SaveIntoDataSourceCommand, qd: QueryDetail): Seq[AtlasEntity] = {
       // source table entity
@@ -334,8 +336,20 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
           Seq.empty
       }
 
-      // support Spark HBase Connector (destination table entity)
-      val outputEntities = SHCEntities.getSHCEntity(node.options)
+      val outputEntities = node.dataSource match {
+        // support Spark HBase Connector (destination table entity)
+        case ds if ds.getClass.getCanonicalName
+          .endsWith(SHCEntities.RELATION_PROVIDER_CLASS_NAME) =>
+          SHCEntities.getSHCEntity(node.options)
+
+        case ds if ds.getClass.getCanonicalName
+          .endsWith(KafkaEntities.RELATION_PROVIDER_CLASS_NAME) =>
+          KafkaEntities.getKafkaEntity(node.options)
+
+        case e =>
+          logWarn(s"Missing output entities: $e")
+          Seq.empty
+      }
 
       // create process entity
       val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
@@ -516,6 +530,9 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
     private val SHC_RELATION_CLASS_NAME =
       "org.apache.spark.sql.execution.datasources.hbase.HBaseRelation"
 
+    val RELATION_PROVIDER_CLASS_NAME =
+      "org.apache.spark.sql.execution.datasources.hbase.DefaultSource"
+
     def unapply(plan: LogicalPlan): Option[Seq[AtlasEntity]] = plan match {
       case l: LogicalRelation
         if l.relation.getClass.getCanonicalName.endsWith(SHC_RELATION_CLASS_NAME) =>
@@ -549,6 +566,21 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
         external.hbaseTableToEntity(cluster, tName, nSpace)
       } else {
         Seq.empty[AtlasEntity]
+      }
+    }
+  }
+
+  object KafkaEntities {
+    val RELATION_PROVIDER_CLASS_NAME = "org.apache.spark.sql.kafka010.KafkaSourceProvider"
+
+    def getKafkaEntity(options: Map[String, String]): Seq[AtlasEntity] = {
+      options.get("topic") match {
+        case Some(topic) =>
+          val cluster = options.get("kafka." + AtlasClientConf.CLUSTER_NAME.key)
+          external.kafkaToEntity(clusterName, KafkaTopicInformation(topic, cluster))
+
+        // not a valid option for Kafka writer, ignored here
+        case _ => Seq.empty[AtlasEntity]
       }
     }
   }

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/BaseResourceIT.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/BaseResourceIT.scala
@@ -37,8 +37,8 @@ abstract class BaseResourceIT extends FunSuite with BeforeAndAfterAll {
     super.beforeAll()
 
 
-    //set high timeouts so that tests do not fail due to read timeouts while you
-    //are stepping through the code in a debugger
+    // set high timeouts so that tests do not fail due to read timeouts while you
+    // are stepping through the code in a debugger
     atlasClientConf.set("atlas.client.readTimeoutMSecs", "100000000")
     atlasClientConf.set("atlas.client.connectTimeoutMSecs", "100000000")
     atlasUrls = Array(atlasClientConf.get(AtlasClientConf.ATLAS_REST_ENDPOINT))

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
@@ -346,7 +346,8 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
   }
 
   test("INSERT INTO MULTIPLE TABLES FROM MULTIPLE TABLES") {
-    val qe = sparkSession.sql(s"WITH view1 AS (SELECT * FROM $inputTable1, $inputTable2, $inputTable3 " +
+    val qe = sparkSession.sql(s"WITH view1 AS " +
+      s"(SELECT * FROM $inputTable1, $inputTable2, $inputTable3 " +
       s"where $inputTable1.a = $inputTable2.b AND $inputTable1.a = $inputTable3.c) " +
       s"FROM view1 INSERT INTO TABLE $outputTable1 SELECT view1.a " +
       s"INSERT INTO TABLE $outputTable2 SELECT view1.b " +

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
@@ -20,15 +20,20 @@ package com.hortonworks.spark.atlas.sql
 import java.nio.file.Files
 
 import com.hortonworks.spark.atlas.sql.testhelper.{AtlasQueryExecutionListener, CreateEntitiesTrackingAtlasClient, DirectProcessSparkExecutionPlanProcessor}
+import com.hortonworks.spark.atlas.sql.testhelper.{AtlasQueryExecutionListener, CreateEntitiesTrackingAtlasClient, DirectProcessSparkExecutionPlanProcessor, KafkaTopicEntityValidator}
 import com.hortonworks.spark.atlas.types.external.KAFKA_TOPIC_STRING
 import com.hortonworks.spark.atlas.types.metadata
 import com.hortonworks.spark.atlas.utils.SparkUtils
 import com.hortonworks.spark.atlas.AtlasClientConf
+import com.hortonworks.spark.atlas.sql.streaming.KafkaTopicInformation
+
 import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.spark.sql.kafka010.KafkaTestUtils
 import org.apache.spark.sql.streaming.{StreamTest, StreamingQuery}
 
-class SparkExecutionPlanProcessorForStreamingQuerySuite extends StreamTest {
+class SparkExecutionPlanProcessorForStreamingQuerySuite
+  extends StreamTest
+  with KafkaTopicEntityValidator {
   import com.hortonworks.spark.atlas.sql.testhelper.AtlasEntityReadHelper._
 
   val brokerProps: Map[String, Object] = Map[String, Object]()
@@ -134,16 +139,6 @@ class SparkExecutionPlanProcessorForStreamingQuerySuite extends StreamTest {
       query.processAllAvailable()
       assert(listener.queryDetails.nonEmpty)
     }
-  }
-
-  private def assertEntitiesKafkaTopicType(topics: Seq[String], entities: Set[AtlasEntity])
-    : Unit = {
-    val kafkaTopicEntities = listAtlasEntitiesAsType(entities.toSeq, KAFKA_TOPIC_STRING)
-    assert(kafkaTopicEntities.size === topics.size)
-
-    assert(kafkaTopicEntities.map(getStringAttribute(_, "name")).toSet === topics.toSet)
-    assert(kafkaTopicEntities.map(getStringAttribute(_, "topic")).toSet === topics.toSet)
-    assert(kafkaTopicEntities.map(getStringAttribute(_, "uri")).toSet === topics.toSet)
   }
 
   private def assertEntitySparkProcessType(

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/KafkaTopicEntityValidator.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/KafkaTopicEntityValidator.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql.testhelper
+
+import org.scalatest.FunSuite
+
+import com.hortonworks.spark.atlas.sql.testhelper.AtlasEntityReadHelper.{getStringAttribute, listAtlasEntitiesAsType}
+import com.hortonworks.spark.atlas.types.external.KAFKA_TOPIC_STRING
+
+import org.apache.atlas.model.instance.AtlasEntity
+
+trait KafkaTopicEntityValidator extends FunSuite {
+
+  def assertEntitiesKafkaTopicType(topics: Seq[String], entities: Set[AtlasEntity]): Unit = {
+    val kafkaTopicEntities = listAtlasEntitiesAsType(entities.toSeq, KAFKA_TOPIC_STRING)
+    assert(kafkaTopicEntities.size === topics.size)
+
+    assert(kafkaTopicEntities.map(getStringAttribute(_, "name")).toSet === topics.toSet)
+    assert(kafkaTopicEntities.map(getStringAttribute(_, "topic")).toSet === topics.toSet)
+    assert(kafkaTopicEntities.map(getStringAttribute(_, "uri")).toSet === topics.toSet)
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch addresses the bug which Kafka topic is not recorded when saving DF to Kafka via DF.save().
This patch also refactors the code regarding testing Kafka entity a bit to reduce redundant lines.

Please note that Spark 2.3 requires a custom patch to apply custom Atlas cluster name, so the code in UT is diverged a bit. (The UT code in master and atlas-1.1 branch are not same.) Other parts are mostly equivalent with #185 (the patch against master branch).

## How was this patch tested?

Added UT. Also manually tested with Spark 2.3.2 (with custom patched spark-sql-kafka module) & Atlas 1.1.

```
spark.sql("create table default.s4_spark_t1_1658400062_b (col1 int)")
spark.sql("insert into s4_spark_t1_1658400062_b values(1)")

spark.sql("select * from s4_spark_t1_1658400062_b").selectExpr("cast(col1 as String) value").write.format("kafka").option("kafka.bootstrap.servers", "localhost:9027").option("topic", "test_spark_topic_WIP_BUG_116565-atlas-1-1").option("kafka.atlas.cluster.name", "custom_cluster").save()
```

![screen shot 2019-01-09 at 8 13 45 pm](https://user-images.githubusercontent.com/1317309/50896275-ed6da780-144b-11e9-8220-ec393aa49c70.png)
![screen shot 2019-01-09 at 8 13 54 pm](https://user-images.githubusercontent.com/1317309/50896276-ed6da780-144b-11e9-96b2-4cc53b224745.png)
![screen shot 2019-01-09 at 8 13 59 pm](https://user-images.githubusercontent.com/1317309/50896277-ed6da780-144b-11e9-8756-48bcf0835838.png)
![screen shot 2019-01-09 at 8 14 05 pm](https://user-images.githubusercontent.com/1317309/50896278-ee063e00-144b-11e9-9028-222c19ff9b7e.png)
