### PR TITLE
[SAC-187][SQL] Harvest Kafka entities as input entities whenever possible in batch execution

### DIFF
--- a/patch/Spark_Kafka_Custom_Atlas_Cluster_Name_2.4.diff
+++ b/patch/Spark_Kafka_Custom_Atlas_Cluster_Name_2.4.diff
@@ -1,0 +1,13 @@
+diff --git a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+index ca05b9e8d3..4be749cff0 100644
+--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
++++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+@@ -60,7 +60,7 @@ private[kafka010] case class KafkaSourceRDDPartition(
+  */
+ private[kafka010] class KafkaSourceRDD(
+     sc: SparkContext,
+-    executorKafkaParams: ju.Map[String, Object],
++    val executorKafkaParams: ju.Map[String, Object],
+     offsetRanges: Seq[KafkaSourceRDDOffsetRange],
+     pollTimeoutMs: Long,
+     failOnDataLoss: Boolean,

--- a/patch/Spark_Kafka_Custom_Atlas_Cluster_Name_2.4.patch
+++ b/patch/Spark_Kafka_Custom_Atlas_Cluster_Name_2.4.patch
@@ -1,0 +1,23 @@
+From 6639ee0a8a3b2f43610288c24605ae6f9e176e62 Mon Sep 17 00:00:00 2001
+From: Jungtaek Lim (HeartSaVioR) <kabhwan@gmail.com>
+Date: Wed, 12 Dec 2018 19:49:09 +0900
+Subject: [PATCH] [BUG-115910][SS] Expose kafka params as field value in KafkaSourceRDD
+
+* This is for enabling custom atlas cluster name to Kafka source/sink in Atlas
+
+Change-Id: I62baf12913e21e318fe64619c1d84e895d46379f
+---
+
+diff --git a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+index ca05b9e..4be749c 100644
+--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
++++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+@@ -60,7 +60,7 @@
+  */
+ private[kafka010] class KafkaSourceRDD(
+     sc: SparkContext,
+-    executorKafkaParams: ju.Map[String, Object],
++    val executorKafkaParams: ju.Map[String, Object],
+     offsetRanges: Seq[KafkaSourceRDDOffsetRange],
+     pollTimeoutMs: Long,
+     failOnDataLoss: Boolean,

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -31,10 +31,10 @@ import org.apache.spark.sql.execution.{FileRelation, FileSourceScanExec, RowData
 import org.apache.spark.sql.execution.command.{CreateDataSourceTableAsSelectCommand, CreateDataSourceTableCommand, CreateViewCommand, LoadDataCommand}
 import org.apache.spark.sql.execution.datasources.{InsertIntoHadoopFsRelationCommand, LogicalRelation, SaveIntoDataSourceCommand}
 import org.apache.spark.sql.hive.execution._
+import org.apache.spark.sql.kafka010.atlas.ExtractFromDataSource
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanExec, WriteToDataSourceV2Exec}
 import org.apache.spark.sql.sources.v2.writer.DataSourceWriter
-
 import com.hortonworks.spark.atlas.AtlasClientConf
 import com.hortonworks.spark.atlas.sql.streaming.KafkaTopicInformation
 import com.hortonworks.spark.atlas.types.{AtlasEntityUtils, external, internal}
@@ -46,17 +46,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
   object InsertIntoHiveTableHarvester extends Harvester[InsertIntoHiveTable] {
     override def harvest(node: InsertIntoHiveTable, qd: QueryDetail): Seq[AtlasEntity] = {
       // source tables entities
-      val tChildren = node.query.collectLeaves()
-      val inputsEntities = tChildren.map {
-        case r: HiveTableRelation => tableToEntities(r.tableMeta)
-        case v: View => tableToEntities(v.desc)
-        case l: LogicalRelation => tableToEntities(l.catalogTable.get)
-        case SHCEntities(shcEntities) => shcEntities
-        case HWCEntities(hwcEntities) => hwcEntities
-        case e =>
-          logWarn(s"Missing unknown leaf node: $e")
-          Seq.empty
-      }
+      val inputsEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
 
       // new table entity
       val outputEntities = tableToEntities(node.table)
@@ -82,31 +72,8 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
     override def harvest(node: InsertIntoHadoopFsRelationCommand, qd: QueryDetail)
         : Seq[AtlasEntity] = {
       // source tables/files entities
-      val tChildren = node.query.collectLeaves()
-      var isFiles = false
-      val inputsEntities = tChildren.map {
-        case r: HiveTableRelation => tableToEntities(r.tableMeta)
-        case v: View => tableToEntities(v.desc)
-        case l: LogicalRelation if l.catalogTable.isDefined =>
-          l.catalogTable.map(tableToEntities(_)).get
-        case SHCEntities(shcEntities) => shcEntities
-        case l: LogicalRelation =>
-          isFiles = true
-          l.relation match {
-            case r: FileRelation => r.inputFiles.map(external.pathToEntity).toSeq
-            case _ => Seq.empty
-          }
-        case HWCEntities(hwcEntities) => hwcEntities
-        case local: LocalRelation =>
-          logInfo("Local Relation to store Spark ML pipelineModel")
-          Seq.empty
-        case e =>
-          logWarn(s"Missing unknown leaf node: $e")
-          Seq.empty
-      }
-
-      val inputTablesEntities = if (isFiles) inputsEntities.flatten.toList
-      else inputsEntities.flatMap(_.headOption).toList
+      val inputsEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
+      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
 
       // new table/file entity
       val outputEntities = node.catalogTable.map(tableToEntities(_)).getOrElse(
@@ -120,8 +87,8 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
         val cleanedOutput = cleanOutput(inputTablesEntities, outputEntities)
         val processEntity = internal.etlProcessToEntity(
           inputTablesEntities, cleanedOutput.headOption.toList, logMap)
-          Seq(processEntity) ++ inputsEntities.flatten ++ cleanedOutput
-        }
+        Seq(processEntity) ++ inputsEntities.flatten ++ cleanedOutput
+      }
     }
   }
 
@@ -130,20 +97,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
         node: CreateHiveTableAsSelectCommand,
         qd: QueryDetail): Seq[AtlasEntity] = {
       // source tables entities
-      val tChildren = node.query.collectLeaves()
-      val inputsEntities = tChildren.map {
-        case r: HiveTableRelation => tableToEntities(r.tableMeta)
-        case v: View => tableToEntities(v.desc)
-        case l: LogicalRelation if l.relation.isInstanceOf[FileRelation] =>
-          l.catalogTable.map(tableToEntities(_)).getOrElse(
-            l.relation.asInstanceOf[FileRelation].inputFiles.map(external.pathToEntity).toSeq)
-        case _: OneRowRelation => Seq.empty
-        case SHCEntities(shcEntities) => shcEntities
-        case HWCEntities(hwcEntities) => hwcEntities
-        case e =>
-          logWarn(s"Missing unknown leaf node: $e")
-          Seq.empty
-      }
+      val inputsEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
 
       // new table entity
       val outputEntities = tableToEntities(node.tableDesc.copy(owner = SparkUtils.currUser()))
@@ -171,19 +125,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
     override def harvest(
         node: CreateDataSourceTableAsSelectCommand,
         qd: QueryDetail): Seq[AtlasEntity] = {
-      val tChildren = node.query.collectLeaves()
-      val inputsEntities = tChildren.map {
-        case r: HiveTableRelation => tableToEntities(r.tableMeta)
-        case v: View => tableToEntities(v.desc)
-        case l: LogicalRelation if l.relation.isInstanceOf[FileRelation] =>
-          l.catalogTable.map(tableToEntities(_)).getOrElse(
-            l.relation.asInstanceOf[FileRelation].inputFiles.map(external.pathToEntity).toSeq)
-        case SHCEntities(shcEntities) => shcEntities
-        case HWCEntities(hwcEntities) => hwcEntities
-        case e =>
-          logWarn(s"Missing unknown leaf node: $e")
-          Seq.empty
-      }
+      val inputsEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
       val outputEntities = tableToEntities(node.table)
       val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
       val outputTableEntities = List(outputEntities.head)
@@ -228,24 +170,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       }
 
       val destEntity = external.pathToEntity(node.storage.locationUri.get.toString)
-      val inputsEntities = qd.qe.sparkPlan.collectLeaves().map {
-        case h if h.getClass.getName == "org.apache.spark.sql.hive.execution.HiveTableScanExec" =>
-          Try {
-            val method = h.getClass.getMethod("relation")
-            method.setAccessible(true)
-            val relation = method.invoke(h).asInstanceOf[HiveTableRelation]
-            tableToEntities(relation.tableMeta)
-          }.getOrElse(Seq.empty)
-
-        case f: FileSourceScanExec =>
-          f.tableIdentifier.map(prepareEntities).getOrElse(
-            f.relation.location.inputFiles.map(external.pathToEntity).toSeq)
-        case SHCEntities(shcEntities) => shcEntities
-        case HWCEntities(hwcEntities) => hwcEntities
-        case e =>
-          logWarn(s"Missing unknown leaf node: $e")
-          Seq.empty
-      }
+      val inputsEntities = discoverInputsEntities(qd.qe.sparkPlan, qd.qe.executedPlan)
 
       val inputs = inputsEntities.flatMap(_.headOption).toList
       val logMap = getPlanInfo(qd)
@@ -307,35 +232,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
   object SaveIntoDataSourceHarvester extends Harvester[SaveIntoDataSourceCommand] {
     override def harvest(node: SaveIntoDataSourceCommand, qd: QueryDetail): Seq[AtlasEntity] = {
       // source table entity
-      val tChildren = node.query.collectLeaves()
-      val inputsEntities = tChildren.map {
-        case r: HiveTableRelation => tableToEntities(r.tableMeta)
-        case v: View => tableToEntities(v.desc)
-        case l: LogicalRelation if l.relation.isInstanceOf[FileRelation] =>
-          l.catalogTable.map(tableToEntities(_)).getOrElse(
-            l.relation.asInstanceOf[FileRelation].inputFiles.map(external.pathToEntity).toSeq)
-        case a: AnalysisBarrier => a.child match {
-            case SHCEntities(shcEntities) => shcEntities
-            case HWCEntities(hwcEntities) => hwcEntities
-            case e =>
-              // SPARK-24867 wraps the whole plan at Spark 2.3.2.
-              // TODO: Remove duplicated code here and above.
-              e.collectLeaves().flatMap {
-                case r: HiveTableRelation => tableToEntities(r.tableMeta)
-                case v: View => tableToEntities(v.desc)
-                case LogicalRelation(fileRelation: FileRelation, _, catalogTable, _) =>
-                  catalogTable.map(tableToEntities(_)).getOrElse(
-                    fileRelation.inputFiles.map(external.pathToEntity).toSeq)
-                case _ => Seq.empty
-              }
-        }
-        case SHCEntities(shcEntities) => shcEntities
-        case HWCEntities(hwcEntities) => hwcEntities
-        case e =>
-          logWarn(s"Missing unknown leaf node: $e")
-          Seq.empty
-      }
-
+      val inputsEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
       val outputEntities = node.dataSource match {
         // support Spark HBase Connector (destination table entity)
         case ds if ds.getClass.getCanonicalName
@@ -384,27 +281,95 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       "sparkPlanDescription" -> qd.qe.sparkPlan.toString())
   }
 
+  private def discoverInputsEntities(
+      plan: LogicalPlan,
+      executedPlan: SparkPlan): Seq[Seq[AtlasEntity]] = {
+    val tChildren = plan.collectLeaves()
+    var foundKafkaRelation = false
+
+    // NOTE: Each element in output should be Sequence which first element represents
+    // actual input entity (rest entities can be dependencies of input entity).
+    // If multiple inputs are extracted from one Relation, they should be provided like
+    // Seq(Seq(entities for first), Seq(entities for second), ...)
+
+    tChildren.flatMap {
+      case r: HiveTableRelation => Seq(tableToEntities(r.tableMeta))
+      case v: View => Seq(tableToEntities(v.desc))
+      case LogicalRelation(fileRelation: FileRelation, _, catalogTable, _) =>
+        catalogTable.map(tbl => Seq(tableToEntities(tbl))).getOrElse(
+          fileRelation.inputFiles.map(file => Seq(external.pathToEntity(file))).toSeq)
+      case a: AnalysisBarrier => a.child match {
+        case SHCEntities(shcEntities) => Seq(shcEntities)
+        case HWCEntities(hwcEntities) => Seq(hwcEntities)
+        case e =>
+          // SPARK-24867 wraps the whole plan at Spark 2.3.2.
+          // TODO: Remove duplicated code here and above.
+          e.collectLeaves().flatMap {
+            case r: HiveTableRelation => Seq(tableToEntities(r.tableMeta))
+            case v: View => Seq(tableToEntities(v.desc))
+            case LogicalRelation(fileRelation: FileRelation, _, catalogTable, _) =>
+              catalogTable.map(tbl => Seq(tableToEntities(tbl))).getOrElse(
+                fileRelation.inputFiles.map(file => Seq(external.pathToEntity(file))).toSeq)
+            case e if KafkaEntities.isKafkaRelationWrappedLogicalRelation(e) =>
+              // Kafka entities will be discovered from physical plan
+              foundKafkaRelation = true
+              Seq.empty
+            case _ => Seq.empty
+          }
+      }
+      case SHCEntities(shcEntities) => Seq(shcEntities)
+      case HWCEntities(hwcEntities) => Seq(hwcEntities)
+      case e if KafkaEntities.isKafkaRelationWrappedLogicalRelation(e) =>
+        // Kafka entities will be discovered from physical plan
+        foundKafkaRelation = true
+        Seq.empty
+
+      case e =>
+        logWarn(s"Missing unknown leaf node: $e")
+        Seq.empty
+    } ++ {
+      if (foundKafkaRelation) {
+        KafkaEntities.getKafkaSourceEntityInExecutedPlan(executedPlan)
+      } else {
+        Seq.empty
+      }
+    }
+  }
+
+  private def discoverInputsEntities(
+      sparkPlan: SparkPlan,
+      executedPlan: SparkPlan): Seq[Seq[AtlasEntity]] = {
+    // NOTE: Each element in output should be Sequence which first element represents
+    // actual input entity (rest entities can be dependencies of input entity).
+    // If multiple inputs are extracted from one Relation, they should be provided like
+    // Seq(Seq(entities for first), Seq(entities for second), ...)
+
+    sparkPlan.collectLeaves().flatMap {
+      case h if h.getClass.getName == "org.apache.spark.sql.hive.execution.HiveTableScanExec" =>
+        Try {
+          val method = h.getClass.getMethod("relation")
+          method.setAccessible(true)
+          val relation = method.invoke(h).asInstanceOf[HiveTableRelation]
+          Seq(tableToEntities(relation.tableMeta))
+        }.getOrElse(Seq.empty)
+
+      case f: FileSourceScanExec =>
+        f.tableIdentifier.map(tbl => Seq(prepareEntities(tbl))).getOrElse(
+          f.relation.location.inputFiles.map(file => Seq(external.pathToEntity(file))).toSeq)
+      case SHCEntities(shcEntities) => Seq(shcEntities)
+      case HWCEntities(hwcEntities) => Seq(hwcEntities)
+      case e =>
+        logWarn(s"Missing unknown leaf node: $e")
+        Seq.empty
+    } ++ {
+      KafkaEntities.getKafkaSourceEntityInExecutedPlan(executedPlan)
+    }
+  }
+
   object HWCHarvester extends Harvester[WriteToDataSourceV2Exec] {
     override def harvest(node: WriteToDataSourceV2Exec, qd: QueryDetail): Seq[AtlasEntity] = {
       // Source table entity
-      val inputsEntities = qd.qe.sparkPlan.collectLeaves().map {
-        case h if h.getClass.getName == "org.apache.spark.sql.hive.execution.HiveTableScanExec" =>
-          Try {
-            val method = h.getClass.getMethod("relation")
-            method.setAccessible(true)
-            val relation = method.invoke(h).asInstanceOf[HiveTableRelation]
-            tableToEntities(relation.tableMeta)
-          }.getOrElse(Seq.empty)
-
-        case f: FileSourceScanExec =>
-          f.tableIdentifier.map(prepareEntities).getOrElse(
-            f.relation.location.inputFiles.map(external.pathToEntity).toSeq)
-        case SHCEntities(shcEntities) => shcEntities
-        case HWCEntities(hwcEntities) => hwcEntities
-        case e =>
-          logWarn(s"Missing unknown leaf node: $e")
-          Seq.empty
-      }
+      val inputsEntities = discoverInputsEntities(qd.qe.sparkPlan, qd.qe.executedPlan)
 
       // Supports Spark HWC (destination table entity)
       val outputEntities = HWCEntities.getHWCEntity(node.writer)
@@ -571,7 +536,25 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
   }
 
   object KafkaEntities {
+    val RELATION_CLASS_NAME = "org.apache.spark.sql.kafka010.KafkaRelation"
     val RELATION_PROVIDER_CLASS_NAME = "org.apache.spark.sql.kafka010.KafkaSourceProvider"
+
+    def isKafkaRelationWrappedLogicalRelation(plan: LogicalPlan): Boolean = plan match {
+      case l: LogicalRelation
+        if l.relation.getClass.getCanonicalName.endsWith(RELATION_CLASS_NAME) => true
+      case _ => false
+    }
+
+    def getKafkaSourceEntityInExecutedPlan(executedPlan: SparkPlan): Seq[Seq[AtlasEntity]] = {
+      val sourceTopics: Set[KafkaTopicInformation] = executedPlan.collectLeaves().flatMap {
+        case r: RowDataSourceScanExec =>
+          ExtractFromDataSource.extractSourceTopicsFromDataSourceV1(r)
+
+        case _ => Nil
+      }.toSet
+
+      sourceTopics.toList.map { topic => external.kafkaToEntity(clusterName, topic) }
+    }
 
     def getKafkaEntity(options: Map[String, String]): Seq[AtlasEntity] = {
       options.get("topic") match {

--- a/spark-atlas-connector/src/main/scala/org/apache/spark/sql/kafka010/atlas/ExtractFromDataSource.scala
+++ b/spark-atlas-connector/src/main/scala/org/apache/spark/sql/kafka010/atlas/ExtractFromDataSource.scala
@@ -19,14 +19,16 @@ package org.apache.spark.sql.kafka010.atlas
 
 import scala.collection.mutable
 import scala.util.control.NonFatal
-
 import com.hortonworks.spark.atlas.AtlasClientConf
 import com.hortonworks.spark.atlas.sql.streaming.KafkaTopicInformation
 import com.hortonworks.spark.atlas.utils.Logging
 
-import org.apache.spark.sql.execution.RDDScanExec
-import org.apache.spark.sql.execution.datasources.v2.{DataSourceRDDPartition, DataSourceV2ScanExec, WriteToDataSourceV2Exec}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.execution.{RDDScanExec, RowDataSourceScanExec}
+import org.apache.spark.sql.execution.datasources.v2.{DataSourceRDDPartition, DataSourceV2ScanExec}
 import org.apache.spark.sql.kafka010._
+
+
 
 
 /**
@@ -39,43 +41,12 @@ object ExtractFromDataSource extends Logging {
   private val currentMirror = runtimeMirror(getClass.getClassLoader)
 
   def extractSourceTopicsFromDataSourceV1(r: RDDScanExec): Seq[KafkaTopicInformation] = {
-    def extractKafkaParams(rdd: KafkaSourceRDD): Option[java.util.Map[String, Object]] = {
-      val rddMirror = currentMirror.reflect(rdd)
-
-      try {
-        val kafkaParamsMethod = typeOf[KafkaSourceRDD].decl(TermName("executorKafkaParams"))
-          .asTerm.accessed.asTerm
-
-        Some(rddMirror.reflectField(kafkaParamsMethod).get
-          .asInstanceOf[java.util.Map[String, Object]])
-      } catch {
-        case NonFatal(_) =>
-          logWarn("WARN: Necessary patch for spark-sql-kafka doesn't look like applied to Spark. " +
-            "Giving up extracting kafka parameter.")
-          None
-      }
-    }
-
-    val topics = new mutable.HashSet[KafkaTopicInformation]()
-    r.rdd.partitions.foreach {
+    r.rdd.partitions.flatMap {
       case e: KafkaSourceRDDPartition =>
-        r.rdd.dependencies.find(p => p.rdd.isInstanceOf[KafkaSourceRDD]).map(_.rdd) match {
-          case Some(kafkaRDD: KafkaSourceRDD) =>
-            val topic = e.offsetRange.topic
-            val customClusterName = extractKafkaParams(kafkaRDD) match {
-              case Some(params) => Option(params.get(AtlasClientConf.CLUSTER_NAME.key))
-                .map(_.toString)
-              case None => None
-            }
-            topics += KafkaTopicInformation(topic, customClusterName)
+        extractSourceTopicsFromKafkaSourceRDDPartition(e, r.rdd)
 
-          case _ =>
-            topics += KafkaTopicInformation(e.offsetRange.topic, None)
-        }
-
-      case _ =>
+      case _ => Nil
     }
-    topics.toSeq
   }
 
   def extractSourceTopicsFromDataSourceV2(
@@ -98,4 +69,62 @@ object ExtractFromDataSource extends Logging {
 
     topics.toSeq
   }
+
+  def extractSourceTopicsFromDataSourceV1(r: RowDataSourceScanExec): Seq[KafkaTopicInformation] = {
+    r.rdd.partitions.flatMap {
+      case e: KafkaSourceRDDPartition =>
+        extractSourceTopicsFromKafkaSourceRDDPartition(e, r.rdd)
+
+      case _ => Nil
+    }
+  }
+
+  def extractSourceTopicsFromKafkaSourceRDDPartition(
+      e: KafkaSourceRDDPartition,
+      rddContainingPartition: RDD[_]): Seq[KafkaTopicInformation] = {
+    def extractKafkaParams(rdd: KafkaSourceRDD): Option[java.util.Map[String, Object]] = {
+      val rddMirror = currentMirror.reflect(rdd)
+
+      try {
+        val kafkaParamsMethod = typeOf[KafkaSourceRDD].decl(TermName("executorKafkaParams"))
+          .asTerm.accessed.asTerm
+
+        Some(rddMirror.reflectField(kafkaParamsMethod).get
+          .asInstanceOf[java.util.Map[String, Object]])
+      } catch {
+        case NonFatal(_) =>
+          logWarn("WARN: Necessary patch for spark-sql-kafka doesn't look like applied to Spark. " +
+            "Giving up extracting kafka parameter.")
+          None
+      }
+    }
+
+    def collectLeaves(rdd: RDD[_]): Seq[RDD[_]] = {
+      // this method is being called with chains of MapPartitionRDDs
+      // so this recursion won't stack up too much
+      if (rdd.dependencies.isEmpty) {
+        Seq(rdd)
+      } else {
+        rdd.dependencies.map(_.rdd).flatMap(collectLeaves)
+      }
+    }
+
+    val topics = new mutable.HashSet[KafkaTopicInformation]()
+    val rdds = collectLeaves(rddContainingPartition)
+    rdds.find(_.isInstanceOf[KafkaSourceRDD]) match {
+      case Some(kafkaRDD: KafkaSourceRDD) =>
+        val topic = e.offsetRange.topic
+        val customClusterName = extractKafkaParams(kafkaRDD) match {
+          case Some(params) => Option(params.get(AtlasClientConf.CLUSTER_NAME.key))
+            .map(_.toString)
+          case None => None
+        }
+        topics += KafkaTopicInformation(topic, customClusterName)
+
+      case _ =>
+        topics += KafkaTopicInformation(e.offsetRange.topic, None)
+    }
+    topics.toSeq
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes harvesting Kafka entities for both input and output in batch query. To reduce the redundant code fix, I had to refactor some code, as well as fix minor bug encountered while refactoring.

Unfortunately batch query in Kafka data source leverages Data Source v1 (even in Spark 2.4) which has to apply custom patch to retrieve parameters. Hopefully necessary custom patch is already presented.

https://github.com/hortonworks-spark/spark-atlas-connector/commit/aadb3c98bfd013e9bcbcdd29f65e5ed6845802ef

## How was this patch tested?

* New UT is added for batch query.
* Existing UT for streaming query is modified as well.
* Manually tested against Spark 2.3.2 (custom patch applied) & Atlas 1.1

```
val kafkaDF = spark.read.format("kafka").option("kafka.bootstrap.servers","localhost:9027").option("subscribe","s5_topic_1_3264278492_b").option("kafka.atlas.cluster.name", "custom_cluster").option("startingOffsets", "earliest").load()

kafkaDF.write.mode("append").saveAsTable("s5_spark_t1_155623032_sac_187_atlas_1_1")
```

![screen shot 2019-01-10 at 5 35 03 pm](https://user-images.githubusercontent.com/1317309/50956070-21090a00-14fe-11e9-9d37-3aa42e33b4cf.png)
![screen shot 2019-01-10 at 5 35 07 pm](https://user-images.githubusercontent.com/1317309/50956072-21a1a080-14fe-11e9-829d-2888d1d99f3a.png)
![screen shot 2019-01-10 at 5 35 13 pm](https://user-images.githubusercontent.com/1317309/50956073-21a1a080-14fe-11e9-8249-505bbc1cab8a.png)

Please note the cluster name in Kafka entity: custom Atlas cluster name is applied.

This closes #187