### PR TITLE
 [SAC-193][SQL] Support to record Structured Streaming (HDFS <> HWC)

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/SparkAtlasStreamingQueryEventTracker.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/SparkAtlasStreamingQueryEventTracker.scala
@@ -20,7 +20,7 @@ package com.hortonworks.spark.atlas
 import scala.collection.mutable
 import org.apache.spark.sql.streaming.StreamingQueryListener
 import org.apache.spark.sql.streaming.StreamingQueryListener._
-import com.hortonworks.spark.atlas.sql.SparkStreamingQueryEventProcessor
+import com.hortonworks.spark.atlas.sql.streaming.SparkStreamingQueryEventProcessor
 import com.hortonworks.spark.atlas.utils.Logging
 
 class SparkAtlasStreamingQueryEventTracker(

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/streaming/HWCStreamingHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/streaming/HWCStreamingHarvester.scala
@@ -26,16 +26,12 @@ import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec
 object HWCStreamingHarvester extends Harvester[WriteToDataSourceV2Exec] {
   override def harvest(node: WriteToDataSourceV2Exec, qd: QueryDetail): Seq[AtlasEntity] = {
     // source topics - can be multiple topics
-    val sourceTopics = KafkaHarvester.extractSourceTopics(node)
-    val inputsEntities: Seq[AtlasEntity] = KafkaHarvester.extractInputEntities(sourceTopics)
+    val inputsEntities: Seq[AtlasEntity] = KafkaHarvester.extractInputEntities(node)
 
     val outputEntities = HWCEntities.getHWCEntity(node.writer)
-    val logMap = KafkaHarvester.makeLogMap(sourceTopics, None, qd)
 
-    val updatedLogMap = logMap ++ Map(
-      "sparkPlanDescription" ->
-      s"${logMap.get("sparkPlanDescription")}\n${qd.qe.sparkPlan.toString()}")
+    val logMap = KafkaHarvester.makeLogMap(node, None, qd)
 
-    KafkaHarvester.makeProcessEntities(inputsEntities, outputEntities, updatedLogMap)
+    KafkaHarvester.makeProcessEntities(inputsEntities, outputEntities, logMap)
   }
 }

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/streaming/KafkaHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/streaming/KafkaHarvester.scala
@@ -17,17 +17,18 @@
 
 package com.hortonworks.spark.atlas.sql.streaming
 
-import scala.collection.mutable
+import scala.util.Try
 
 import org.apache.atlas.model.instance.AtlasEntity
-import org.apache.spark.sql.execution.RDDScanExec
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
+import org.apache.spark.sql.execution.{FileSourceScanExec, RDDScanExec}
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2ScanExec, WriteToDataSourceV2Exec}
 import org.apache.spark.sql.kafka010._
 import org.apache.spark.sql.execution.streaming.sources.MicroBatchWriter
 import org.apache.spark.sql.kafka010.atlas.ExtractFromDataSource
 
 import com.hortonworks.spark.atlas.AtlasClientConf
-import com.hortonworks.spark.atlas.sql.QueryDetail
+import com.hortonworks.spark.atlas.sql.{CommandsHarvester, QueryDetail}
 import com.hortonworks.spark.atlas.types.{AtlasEntityUtils, external, internal}
 import com.hortonworks.spark.atlas.utils.{Logging, SparkUtils}
 
@@ -62,16 +63,16 @@ object KafkaHarvester extends AtlasEntityUtils with Logging {
       writer: WriteToDataSourceV2Exec,
       qd: QueryDetail) : Seq[AtlasEntity] = {
     // source topics - can be multiple topics
-    val sourceTopics = extractSourceTopics(writer)
-    val inputsEntities: Seq[AtlasEntity] = extractInputEntities(sourceTopics)
+    val inputsEntities: Seq[AtlasEntity] = extractInputEntities(writer)
 
     val outputEntities = if (targetTopic.isDefined) {
       external.kafkaToEntity(clusterName, targetTopic.get)
     } else {
+      logInfo(s"Could not get destination topic.")
       Seq.empty
     }
 
-    val logMap = makeLogMap(sourceTopics, targetTopic, qd)
+    val logMap = makeLogMap(writer, targetTopic, qd)
     makeProcessEntities(inputsEntities, outputEntities, logMap)
   }
 
@@ -83,28 +84,40 @@ object KafkaHarvester extends AtlasEntityUtils with Logging {
     }.toSet
   }
 
-  def extractInputEntities(
-       sourceTopics: Set[KafkaTopicInformation]): Seq[AtlasEntity] = {
-    sourceTopics
-      .toList.flatMap { topic => external.kafkaToEntity(clusterName, topic) }
+  def extractInputEntities(node: WriteToDataSourceV2Exec): Seq[AtlasEntity] = {
+    val kafkaInputEntities = extractSourceTopics(node).toList
+      .flatMap { topic => external.kafkaToEntity(clusterName, topic) }
+
+    val otherInputEntities = node.query.collectLeaves().flatMap {
+      case f: FileSourceScanExec =>
+        f.tableIdentifier.map(CommandsHarvester.prepareEntities).getOrElse(
+          f.relation.location.inputFiles.map(external.pathToEntity).toSeq)
+      case e =>
+        logWarn(s"Missing unknown leaf node: $e")
+        Seq.empty
+    }
+
+    kafkaInputEntities ++ otherInputEntities
   }
 
   def makeLogMap(
-      sourceTopics: Set[KafkaTopicInformation],
+      node: WriteToDataSourceV2Exec,
       targetTopic: Option[KafkaTopicInformation],
       qd: QueryDetail): Map[String, String] = {
     // create process entity
-    val strSourceTopics = sourceTopics.toList
-      .map(KafkaTopicInformation.getQualifiedName(_, clusterName)).sorted.mkString(", ")
-
-    val pDescription = StringBuilder.newBuilder.append(s"Topics subscribed( $strSourceTopics )")
-
+    val sourceTopics = extractSourceTopics(node).toList
+    val pDescription = StringBuilder.newBuilder
+    if (sourceTopics.nonEmpty) {
+      val strSourceTopics = sourceTopics.map(
+        KafkaTopicInformation.getQualifiedName(_, clusterName)).sorted.mkString(", ")
+      pDescription.append(s"Topics subscribed( $strSourceTopics )")
+    }
     if (targetTopic.isDefined) {
       val strTargetTopic = KafkaTopicInformation.getQualifiedName(targetTopic.get, clusterName)
       pDescription.append(s" Topics written into( $strTargetTopic )")
-    } else {
-      logInfo(s"Can not get dest topic")
     }
+
+    pDescription.append(s"\n${qd.qe.sparkPlan.toString()}")
 
     Map(
       "executionId" -> qd.executionId.toString,

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/streaming/SparkStreamingQueryEventProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/streaming/SparkStreamingQueryEventProcessor.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.hortonworks.spark.atlas.sql
+package com.hortonworks.spark.atlas.sql.streaming
 
 import org.apache.spark.sql.streaming.StreamingQueryListener.QueryProgressEvent
 import com.hortonworks.spark.atlas._


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to record Structured Streaming HDFS <> HWC.

```scala
import org.apache.spark.sql._
import com.hortonworks.spark.sql.hive.llap.HiveWarehouseBuilder
val hive = HiveWarehouseBuilder.session(spark).build()
import org.apache.spark.sql.types._

val schema = StructType(
  Array(
    StructField("col0", StringType),
    StructField("col1", StringType)))

spark.readStream.schema(schema).json("/tmp/hyukjinkwon_json_data")
 .writeStream
 .format("com.hortonworks.spark.sql.hive.llap.streaming.HiveStreamingDataSource")
 .option("table", "s12_hive_1_562160834")
 .option("checkpointLocation", "/tmp/s12_hive_1_562160834/check")
 .option("metastoreUri", "thrift://ctr-e139-1542663976389-39519-01-000003.hwx.site:9083,thrift://ctr-e139-1542663976389-39519-01-000005.hwx.site:9083")
 .start()
```

The problem was:
 1.  in microbatch the writer is wrapped by `InternalRowMicroBatchWriter`. Wrapped `writer` is inaccessible so we should create the factory to identify the data source.
 2. for input, File sources were not being handled `FileSourceScanExec` (for both Kafka and HWC).

## How was this patch tested?

Manually tested:

![screen shot 2019-01-10 at 6 32 27 pm](https://user-images.githubusercontent.com/6477701/50964012-36cffc80-1509-11e9-85e6-c57f8deb9061.png)


Closes #193