### PR TITLE
[SAC-201][SQL] Add support for Kafka client for HWC

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClient.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasClient.scala
@@ -33,8 +33,6 @@ trait AtlasClient extends Logging {
 
   def updateAtlasTypeDefs(typeDefs: AtlasTypesDef): Unit
 
-  def findEntity(typeNang: String, qualifiedName: String): AtlasEntity
-
   final def createEntities(entities: Seq[AtlasEntity]): Unit = this.synchronized {
     if (entities.isEmpty) {
       return
@@ -83,11 +81,6 @@ trait AtlasClient extends Logging {
 
 object AtlasClient {
   @volatile private var client: AtlasClient = null
-
-  protected[atlas] def atlasClient(): AtlasClient = {
-    assert(client != null, "atlasClient(conf) should be called first.")
-    client
-  }
 
   def atlasClient(conf: AtlasClientConf): AtlasClient = {
     if (client == null) {

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/KafkaAtlasClient.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/KafkaAtlasClient.scala
@@ -51,10 +51,6 @@ class KafkaAtlasClient(atlasClientConf: AtlasClientConf) extends AtlasHook with 
     throw new UnsupportedOperationException("Kafka atlas client doesn't support update type defs")
   }
 
-  override def findEntity(typeName: String, qualifiedName: String): AtlasEntity = {
-    throw new UnsupportedOperationException("Kafka atlas client doesn't support find entities")
-  }
-
   override protected def doCreateEntities(entities: Seq[AtlasEntity]): Unit = {
     val entitiesWithExtInfo = new AtlasEntitiesWithExtInfo()
     entities.foreach(entitiesWithExtInfo.addEntity)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/RestAtlasClient.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/RestAtlasClient.scala
@@ -62,10 +62,6 @@ class RestAtlasClient(atlasClientConf: AtlasClientConf) extends AtlasClient {
     client.updateAtlasTypeDefs(typeDefs)
   }
 
-  override def findEntity(typeName: String, qualifiedName: String): AtlasEntity = {
-    client.getEntityByAttribute(typeName, Map("qualifiedName" -> qualifiedName).asJava).getEntity
-  }
-
   override protected def doCreateEntities(entities: Seq[AtlasEntity]): Unit = {
     val entitesWithExtInfo = new AtlasEntitiesWithExtInfo()
     entities.foreach(entitesWithExtInfo.addEntity)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -271,6 +271,8 @@ object external {
 
   // ================== Hive entities (Hive Warehouse Connector) =====================
   val HWC_TABLE_TYPE_STRING = "hive_table"
+  val HWC_DB_TYPE_STRING = "hive_db"
+  val HWC_STORAGEDESC_TYPE_STRING = "hive_storagedesc"
 
   def hwcTableUniqueAttribute(
       cluster: String,
@@ -283,10 +285,25 @@ object external {
       db: String,
       table: String,
       cluster: String): Seq[AtlasEntity] = {
-    // For HWC tables, we're not going to create new Hive table entities within Spark side.
-    // Therefore, it finds the existing Hive table entities.
-    val entity = AtlasClient.atlasClient().findEntity(
-      HWC_TABLE_TYPE_STRING, hwcTableUniqueAttribute(cluster, db, table))
-    Option(entity).toSeq
+
+    val dbEntity = new AtlasEntity(HWC_DB_TYPE_STRING)
+    dbEntity.setAttribute("qualifiedName",
+      hiveDbUniqueAttribute(cluster, db.toLowerCase))
+    dbEntity.setAttribute("name", db.toLowerCase)
+
+    val sdEntity = new AtlasEntity(HWC_STORAGEDESC_TYPE_STRING)
+    sdEntity.setAttribute("qualifiedName",
+      hiveStorageDescUniqueAttribute(cluster, db, table))
+
+    val tblEntity = new AtlasEntity(HWC_TABLE_TYPE_STRING)
+    tblEntity.setAttribute("qualifiedName",
+      hiveTableUniqueAttribute(cluster, db, table))
+    tblEntity.setAttribute("name", table)
+    tblEntity.setAttribute("db",
+      AtlasUtils.entityToReference(dbEntity, useGuid = false))
+    tblEntity.setAttribute("sd",
+      AtlasUtils.entityToReference(sdEntity, useGuid = false))
+
+    Seq(tblEntity)
   }
 }

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessorSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessorSuite.scala
@@ -192,8 +192,6 @@ class FirehoseAtlasClient(conf: AtlasClientConf) extends AtlasClient {
     new AtlasTypesDef()
   }
 
-  override def findEntity(typeNang: String, qualifiedName: String): AtlasEntity = { null }
-
   override protected def doCreateEntities(entities: Seq[AtlasEntity]): Unit = {
     entities.foreach { e =>
       createEntityCall(e.getTypeName) =

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/CreateEntitiesTrackingAtlasClient.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/CreateEntitiesTrackingAtlasClient.scala
@@ -48,6 +48,4 @@ class CreateEntitiesTrackingAtlasClient extends AtlasClient {
 
   override protected def doUpdateEntityWithUniqueAttr(entityType: String, attribute: String,
                                                       entity: AtlasEntity): Unit = {}
-
-  override def findEntity(typeNang: String, qualifiedName: String): AtlasEntity = { null }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, HWC entities are not created if Kafka client is used. This PR proposes to add the support for HWC with Kafka client.

For instance, the codes below does not create the lineage for HWC operations.

```scala
sql("create table test using parquet location '/tmp/hyukjin_parquet'")
import com.hortonworks.spark.sql.hive.llap.HiveWarehouseBuilder
val hive = HiveWarehouseBuilder.session(spark).build()
spark.sql("select * from test").write.mode("append").format("com.hortonworks.spark.sql.hive.llap.HiveWarehouseConnector").option("table", "hive_t2_hyukjin").save()
```

Previous way used `findEntity` which only exists in REST client. The problem was nested entity reference problem. For instance, table entity needs storage description entity but when we harvest we don't have full information for this nested entity. So, there had to be a way to refer the nested entity. This was resolved by `AtlasUtils.entityToReference`.

Therefore, this PR removes the previous way and use `AtlasUtils.entityToReference` to refer the nested entities.

## How was this patch tested?

![screen shot 2019-01-15 at 3 05 41 pm](https://user-images.githubusercontent.com/6477701/51164190-2045ee80-18d7-11e9-8045-ca0e7d700a42.png)

![screen shot 2019-01-15 at 3 06 48 pm](https://user-images.githubusercontent.com/6477701/51164220-32c02800-18d7-11e9-9598-4da31021b10f.png)


Closes #201