### PR TITLE
[SAC-208][BUILD] shade & relocate commons-configuration

### DIFF
--- a/spark-atlas-connector-assembly/pom.xml
+++ b/spark-atlas-connector-assembly/pom.xml
@@ -90,6 +90,10 @@
                   <pattern>org.apache.htrace</pattern>
                   <shadedPattern>org.apache.atlas.htrace</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>org.apache.commons.configuration</pattern>
+                  <shadedPattern>org.apache.atlas.commons.configuration</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR shades and relocates Atlas's commons-configuration dependency to avoid conflicts when running SparkAtlasModel (to create models before running SAC). This is needed to enable #166.

## How was this patch tested?

Passed UTs, tested with Spark 2.4 & Atlas 1.1 (master branch), Spark 2.3.2 & Atlas 1.1 (atlas-1.1 branch)
