### PR TITLE
ISSUE-212 Support interactive authentication in pre-creating models

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/SparkAtlasModel.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/SparkAtlasModel.scala
@@ -58,6 +58,21 @@ object SparkAtlasModel extends Logging {
   def main(args: Array[String]): Unit = {
     val atlasClientConf = new AtlasClientConf
 
+    if (args.length > 0 && args.contains("--interactive-auth")) {
+      // input user name and password
+      val console = System.console
+      val username = console.readLine("Username: ")
+      val password = console.readPassword("Password: ")
+
+      if (username != null && password != null) {
+        atlasClientConf.set(AtlasClientConf.CLIENT_USERNAME, username.trim)
+        atlasClientConf.set(AtlasClientConf.CLIENT_PASSWORD, String.valueOf(password).trim)
+      }
+    }
+
+    logInfo(s"Authentication information - username " +
+      s"${atlasClientConf.get(AtlasClientConf.CLIENT_USERNAME)}")
+
     val atlasClient = new RestAtlasClient(atlasClientConf)
     checkAndCreateTypes(atlasClient)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch provides the option to get auth information interactively on SparkAtlasModel CLI, which gets rid of necessary to store auth information as plain text in properties file.

## How was this patch tested?

Manually tested with additional log messages when verifying. Now the log message which shows username only left.

This closes #212 