### PR TITLE
[SAC-215][BUILD] Shade & relocate jersey 1.x / jackson, remove hbase-bridge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
     <integration.test.enabled>false</integration.test.enabled>
     <jersey.version>1.19</jersey.version>
     <scoverage.plugin.version>1.3.0</scoverage.plugin.version>
+    <!-- jackson version pulled from atlas-intg -->
+    <jackson.version>2.9.6</jackson.version>
   </properties>
 
   <modules>
@@ -73,6 +75,57 @@
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-json</artifactId>
       <version>${jersey.version}</version>
+    </dependency>
+
+    <!-- enumerating jackson dependencies to relocate: avoid conflict with Spark -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-base</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jaxb-annotations</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <!--
+    This is needed since we pull Spark dependencies in test scope.
+    Without replacing jackson-module-scala to matched version, it complains
+    with incompatible version.
+    Given we shade and relocate all the jackson dependencies, it doesn't
+    conflict with Spark in runtime.
+    -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-scala_2.11</artifactId>
+      <version>${jackson.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -193,12 +246,6 @@
           <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.atlas</groupId>
-      <artifactId>hbase-bridge</artifactId>
-      <version>${atlas.version}</version>
     </dependency>
 
     <dependency>

--- a/spark-atlas-connector-assembly/pom.xml
+++ b/spark-atlas-connector-assembly/pom.xml
@@ -84,16 +84,33 @@
               <relocations>
                 <relocation>
                   <pattern>org.apache.hadoop.hbase</pattern>
-                  <shadedPattern>org.apache.atlas.hbase</shadedPattern>
+                  <shadedPattern>com.hortonworks.spark.atlas.shade.org.apache.hbase</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.htrace</pattern>
-                  <shadedPattern>org.apache.atlas.htrace</shadedPattern>
+                  <shadedPattern>com.hortonworks.spark.atlas.shade.org.apache.htrace</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.commons.configuration</pattern>
-                  <shadedPattern>org.apache.atlas.commons.configuration</shadedPattern>
+                  <shadedPattern>com.hortonworks.spark.atlas.shade.org.apache.commons.configuration</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>com.sun.jersey</pattern>
+                  <shadedPattern>com.hortonworks.spark.atlas.shade.com.sun.jersey</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.codehaus.jackson</pattern>
+                  <shadedPattern>com.hortonworks.spark.atlas.shade.org.codehaus.jackson</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.ws.rs</pattern>
+                  <shadedPattern>com.hortonworks.spark.atlas.javax.ws.rs</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.fasterxml.jackson</pattern>
+                  <shadedPattern>com.hortonworks.spark.atlas.com.fasterxml.jackson</shadedPattern>
+                </relocation>
+
               </relocations>
             </configuration>
           </execution>

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -23,7 +23,6 @@ import java.util.Date
 
 import scala.collection.JavaConverters._
 import org.apache.atlas.AtlasConstants
-import org.apache.atlas.hbase.bridge.HBaseAtlasHook._
 import org.apache.atlas.model.instance.{AtlasEntity, AtlasObjectId}
 import org.apache.commons.lang.RandomStringUtils
 import org.apache.hadoop.fs.Path
@@ -145,6 +144,7 @@ object external {
   val HBASE_TABLE_STRING = "hbase_table"
   val HBASE_COLUMNFAMILY_STRING = "hbase_column_family"
   val HBASE_COLUMN_STRING = "hbase_column"
+  val HBASE_TABLE_QUALIFIED_NAME_FORMAT = "%s:%s@%s"
 
   def hbaseTableToEntity(cluster: String, tableName: String, nameSpace: String)
       : Seq[AtlasEntity] = {
@@ -155,6 +155,18 @@ object external {
     hbaseEntity.setAttribute(AtlasConstants.CLUSTER_NAME_ATTRIBUTE, cluster)
     hbaseEntity.setAttribute("uri", nameSpace.toLowerCase + ":" + tableName.toLowerCase)
     Seq(hbaseEntity)
+  }
+
+  private def getTableQualifiedName(
+      clusterName: String,
+      nameSpace: String,
+      tableName: String): String = {
+    if (clusterName == null || nameSpace == null || tableName == null) {
+      null
+    } else {
+      String.format(HBASE_TABLE_QUALIFIED_NAME_FORMAT, nameSpace.toLowerCase,
+        tableName.toLowerCase.substring(tableName.toLowerCase.indexOf(":") + 1), clusterName)
+    }
   }
 
   // ================ Kafka entities =======================


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch shades and relocates jersey 1.x (and old jackson which is compatible with) to avoid conflict with jersey 2.x in Spark UI. 

This patch also shades and relocates jackson 2.9.6 which Atlas client is pulling, since Spark 2.4.0 leverages lower version of jackson which is not compatible at some point.

This patch also removes hbase-bridge from dependency, since it pulls plenty of dependencies while it can be just replaced via copying some codes (less than 10 lines).

## How was this patch tested?

Existing UT passed, manually tested via following steps:

1) manual model creation succeeded

> java -cp "/atlas-dist/sac-archives/spark-atlas-connector-assembly-0.1.0-SNAPSHOT-SAC-215.jar:/spark-dist/releases/spark-2.4.0-bin-hadoop2.7/jars/*:/spark-dist/releases/spark-2.4.0-bin-hadoop2.7/conf" com.hortonworks.spark.atlas.types.SparkAtlasModel --interactive-auth

```
Username: admin
Password:
2019-04-23 06:57:18 INFO  ApplicationProperties:85 - Looking for atlas-application.properties in classpath
2019-04-23 06:57:18 INFO  ApplicationProperties:98 - Loading atlas-application.properties from file:/spark-dist/releases/spark-2.4.0-bin-hadoop2.7/conf/atlas-application.properties
2019-04-23 06:57:18 INFO  ApplicationProperties:242 - Property (set to default) atlas.graph.cache.db-cache = true
2019-04-23 06:57:18 INFO  ApplicationProperties:242 - Property (set to default) atlas.graph.cache.db-cache-clean-wait = 20
2019-04-23 06:57:18 INFO  ApplicationProperties:242 - Property (set to default) atlas.graph.cache.db-cache-size = 0.5
2019-04-23 06:57:18 INFO  ApplicationProperties:242 - Property (set to default) atlas.graph.cache.tx-cache-size = 15000
2019-04-23 06:57:18 INFO  ApplicationProperties:242 - Property (set to default) atlas.graph.cache.tx-dirty-size = 120
2019-04-23 06:57:18 INFO  SparkAtlasModel$:39 - Authentication information - username admin
2019-04-23 06:57:18 INFO  AtlasBaseClient:295 - Client has only one service URL, will use that for all actions: http://localhost:21000
2019-04-23 06:57:18 INFO  AtlasBaseClient:361 - method=GET path=api/atlas/v2/types/typedefs/ contentType=application/json; charset=UTF-8 accept=application/json status=200
...
2019-04-23 06:57:19 INFO  SparkAtlasModel$:39 - Create all the types def: ...
2019-04-23 06:57:40 INFO  AtlasBaseClient:361 - method=POST path=api/atlas/v2/types/typedefs/ contentType=application/json; charset=UTF-8 accept=application/json status=200
2019-04-23 06:57:40 INFO  SparkAtlasModel$:39 - Spark Atlas model is created
```

2) ran simple query with spark-shell succeed (change tracked in Atlas)

> ./bin/spark-shell --jars /atlas-dist/sac-archives/spark-atlas-connector-assembly-0.1.0-SNAPSHOT-SAC-215.jar --master "local[*]" --name "process_1" --conf spark.extraListeners=com.hortonworks.spark.atlas.SparkAtlasEventTracker --conf spark.sql.queryExecutionListeners=com.hortonworks.spark.atlas.SparkAtlasEventTracker --conf spark.sql.streaming.streamingQueryListeners=com.hortonworks.spark.atlas.SparkAtlasStreamingQueryEventTracker

```
scala> spark.range(10).write.json("/tmp/1/json-sac-167")
scala> spark.sql("CREATE TABLE test_json_788987_aabbccdd USING json location '/tmp/1/json-sac-167'")
```

* requesting `/allexecutors` 

![Screen Shot 2019-04-23 at 5 59 56 AM](https://user-images.githubusercontent.com/1317309/56536424-fe749b80-6598-11e9-8032-3dce19d55aa2.png)

* changes in Atlas screenshots

![Screen Shot 2019-04-23 at 7 03 10 AM](https://user-images.githubusercontent.com/1317309/56536558-4e536280-6599-11e9-822c-af6aabb33e03.png)
![Screen Shot 2019-04-23 at 7 04 12 AM](https://user-images.githubusercontent.com/1317309/56536560-4eebf900-6599-11e9-875a-0a34dba35411.png)
![Screen Shot 2019-04-23 at 7 04 18 AM](https://user-images.githubusercontent.com/1317309/56536561-4eebf900-6599-11e9-837c-6e1948d8ac2c.png)

This closes #215 