### PR TITLE
[SAC-219][SQL] Fix issue on non-file stream source/sink query when streamingQueryListeners is specified

### DIFF
--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/AtlasStreamingQueryProgressListener.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/AtlasStreamingQueryProgressListener.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql.testhelper
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.streaming.StreamingQueryListener
+import org.apache.spark.sql.streaming.StreamingQueryListener.{QueryProgressEvent, QueryStartedEvent, QueryTerminatedEvent}
+
+class AtlasStreamingQueryProgressListener extends StreamingQueryListener {
+  val progressEvents = new mutable.MutableList[QueryProgressEvent]()
+
+  def onQueryStarted(event: QueryStartedEvent): Unit = {}
+
+  def onQueryProgress(event: QueryProgressEvent): Unit = {
+    progressEvents += event
+  }
+
+  def onQueryTerminated(event: QueryTerminatedEvent): Unit = {}
+
+  def clear(): Unit = {
+    progressEvents.clear()
+  }
+}

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/DirectProcessSparkStreamingQueryEventProcessor.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/DirectProcessSparkStreamingQueryEventProcessor.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql.testhelper
+
+import org.apache.spark.sql.streaming.StreamingQueryListener
+
+import com.hortonworks.spark.atlas.sql.streaming.SparkStreamingQueryEventProcessor
+import com.hortonworks.spark.atlas.{AtlasClient, AtlasClientConf}
+
+class DirectProcessSparkStreamingQueryEventProcessor(
+    atlasClient: AtlasClient,
+    atlasClientConf: AtlasClientConf)
+  extends SparkStreamingQueryEventProcessor(atlasClient, atlasClientConf) {
+
+  override def process(e: StreamingQueryListener.QueryProgressEvent): Unit = super.process(e)
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fixes the issue when streamingQueryListeners is referred as `SparkAtlasStreamingQueryEventTracker` and the streaming query doesn't use file streaming source/sink. I've described what is happening in #219 so skip describing here.

## How was this patch tested?

* Changed UT to check both paths (`SparkExecutionPlanProcessor`, `SparkStreamingQueryEventProcessor`) when running streaming query tests. 
* Also added UT to test file to file streaming query.
* Manually tested the same.

This closes #219 