### PR TITLE
[SAC-168][SQL] Apply Spark catalog model definitions to Hive metastore catalog entities

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkCatalogEventProcessor.scala
@@ -81,7 +81,6 @@ class SparkCatalogEventProcessor(
             .filterNot(e => excludedTypes.contains(e.getTypeName))
             .map { e =>
               e.removeAttribute("columns")
-              e.removeAttribute("spark_schema")
               e
             }
           atlasClient.createEntities(cleanedEntities)
@@ -182,7 +181,6 @@ class SparkCatalogEventProcessor(
                 .filterNot(e => excludedTypes.contains(e.getTypeName))
                 .map { e =>
                   e.removeAttribute("columns")
-                  e.removeAttribute("spark_schema")
                   e
                 }
               atlasClient.createEntities(cleanedEntities)
@@ -197,7 +195,7 @@ class SparkCatalogEventProcessor(
               atlasClient.createEntities(schemaEntities)
 
               val tableEntity = new AtlasEntity(tableType(isHiveTbl))
-              tableEntity.setAttribute("spark_schema", schemaEntities.asJava)
+              tableEntity.setAttribute("columns", schemaEntities.asJava)
               atlasClient.updateEntityWithUniqueAttr(
                 tableType(isHiveTbl),
                 tableUniqueAttribute(db, table, isHiveTbl),

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
@@ -150,13 +150,11 @@ class SparkExecutionPlanProcessor(
           .map {
             case e if dbTypes.contains(e.getTypeName) =>
               e.removeAttribute("columns")
-              e.removeAttribute("spark_schema")
               e
             case e if e.getTypeName.equals(metadata.PROCESS_TYPE_STRING) =>
               Seq(e.getAttribute("inputs"), e.getAttribute("outputs")).foreach { list =>
                 list.asInstanceOf[SeqWrapper[AtlasEntity]].underlying.foreach { o =>
                   o.removeAttribute("columns")
-                  o.removeAttribute("spark_schema")
                 }
               }
               e

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/AtlasEntityUtils.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/AtlasEntityUtils.scala
@@ -97,9 +97,9 @@ trait AtlasEntityUtils {
       table: String,
       isHiveTable: Boolean): List[AtlasEntity] = {
     if (isHiveTable) {
-      external.hiveSchemaToEntities(schema, clusterName, db, table)
+      external.hiveColumnToEntities(schema, clusterName, db, table)
     } else {
-      internal.sparkSchemaToEntities(schema, db, table)
+      internal.sparkColumnToEntities(schema, db, table)
     }
   }
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -190,10 +190,15 @@ object external {
   }
 
   // ================== Spark's Hive Catalog entities =====================
-  val HIVE_DB_TYPE_STRING = "spark_db"
-  val HIVE_STORAGEDESC_TYPE_STRING = "spark_storagedesc"
-  val HIVE_COLUMN_TYPE_STRING = "spark_column"
-  val HIVE_TABLE_TYPE_STRING = "spark_table"
+
+  // Note: given that we use Spark model types for Hive catalog entities (except HWC),
+  // Hive catalog entities should follow Spark model definitions.
+  // In Atlas, the attributes which are not in definition are ignored with WARN messages.
+
+  val HIVE_DB_TYPE_STRING = metadata.DB_TYPE_STRING
+  val HIVE_STORAGEDESC_TYPE_STRING = metadata.STORAGEDESC_TYPE_STRING
+  val HIVE_COLUMN_TYPE_STRING = metadata.COLUMN_TYPE_STRING
+  val HIVE_TABLE_TYPE_STRING = metadata.TABLE_TYPE_STRING
 
   def hiveDbUniqueAttribute(cluster: String, db: String): String = s"${db.toLowerCase}@$cluster"
 
@@ -201,7 +206,6 @@ object external {
                        cluster: String,
                        owner: String): Seq[AtlasEntity] = {
     val dbEntity = new AtlasEntity(HIVE_DB_TYPE_STRING)
-
     dbEntity.setAttribute("qualifiedName",
       hiveDbUniqueAttribute(cluster, dbDefinition.name.toLowerCase))
     dbEntity.setAttribute("name", dbDefinition.name.toLowerCase)
@@ -260,12 +264,12 @@ object external {
     val sdEntity = new AtlasEntity(HIVE_STORAGEDESC_TYPE_STRING)
     sdEntity.setAttribute("qualifiedName",
       hiveStorageDescUniqueAttribute(cluster, db, table, isTempTable))
+    storageFormat.locationUri.foreach { u => sdEntity.setAttribute("location", u.toString) }
     storageFormat.inputFormat.foreach(sdEntity.setAttribute("inputFormat", _))
     storageFormat.outputFormat.foreach(sdEntity.setAttribute("outputFormat", _))
+    storageFormat.serde.foreach(sdEntity.setAttribute("serde", _))
     sdEntity.setAttribute("compressed", storageFormat.compressed)
     sdEntity.setAttribute("parameters", storageFormat.properties.asJava)
-    storageFormat.serde.foreach(sdEntity.setAttribute("name", _))
-    storageFormat.locationUri.foreach { u => sdEntity.setAttribute("location", u.toString) }
     Seq(sdEntity)
   }
 
@@ -280,7 +284,7 @@ object external {
     s"${parts(0)}.${column.toLowerCase}@${parts(1)}"
   }
 
-  def hiveSchemaToEntities(
+  def hiveColumnToEntities(
       schema: StructType,
       cluster: String,
       db: String,
@@ -317,10 +321,10 @@ object external {
   }
 
   def hiveTableToEntities(
-      tblDefination: CatalogTable,
+      tblDefinition: CatalogTable,
       cluster: String,
       mockDbDefinition: Option[CatalogDatabase] = None): Seq[AtlasEntity] = {
-    val tableDefinition = SparkUtils.getCatalogTableIfExistent(tblDefination)
+    val tableDefinition = SparkUtils.getCatalogTableIfExistent(tblDefinition)
     val db = tableDefinition.identifier.database.getOrElse("default")
     val table = tableDefinition.identifier.table
     val dbDefinition = mockDbDefinition.getOrElse(SparkUtils.getExternalCatalog().getDatabase(db))
@@ -329,7 +333,7 @@ object external {
     val sdEntities = hiveStorageDescToEntities(
       tableDefinition.storage, cluster, db, table
       /* isTempTable = false  Spark doesn't support temp table */)
-    val schemaEntities = hiveSchemaToEntities(
+    val schemaEntities = hiveColumnToEntities(
       tableDefinition.schema, cluster, db, table /* , isTempTable = false */)
 
     val tblEntity = new AtlasEntity(HIVE_TABLE_TYPE_STRING)
@@ -339,23 +343,23 @@ object external {
     tblEntity.setAttribute("owner", tableDefinition.owner)
     tblEntity.setAttribute("ownerType", "USER")
     tblEntity.setAttribute("createTime", new Date(tableDefinition.createTime))
-    tableDefinition.comment.foreach(tblEntity.setAttribute("comment", _))
-    tblEntity.setAttribute("db", dbEntities.head)
-    tblEntity.setAttribute("sd", sdEntities.head)
     tblEntity.setAttribute("parameters", tableDefinition.properties.asJava)
+    tableDefinition.comment.foreach(tblEntity.setAttribute("comment", _))
     tableDefinition.viewText.foreach(tblEntity.setAttribute("viewOriginalText", _))
+    tblEntity.setAttribute("db", dbEntities.head)
     tblEntity.setAttribute("tableType", tableDefinition.tableType.name)
+    tblEntity.setAttribute("sd", sdEntities.head)
     tblEntity.setAttribute("columns", schemaEntities.asJava)
 
     Seq(tblEntity) ++ dbEntities ++ sdEntities ++ schemaEntities
   }
 
   def hiveTableToEntitiesForAlterTable(
-      tblDefination: CatalogTable,
+      tblDefinition: CatalogTable,
       cluster: String,
       mockDbDefinition: Option[CatalogDatabase] = None): Seq[AtlasEntity] = {
     val typesToPick = Seq(HIVE_TABLE_TYPE_STRING, HIVE_COLUMN_TYPE_STRING)
-    val entities = hiveTableToEntities(tblDefination, cluster, mockDbDefinition)
+    val entities = hiveTableToEntities(tblDefinition, cluster, mockDbDefinition)
 
     val dbEntity = entities.filter(e => e.getTypeName.equals(HIVE_DB_TYPE_STRING)).head
     val sdEntity = entities.filter(e => e.getTypeName.equals(HIVE_STORAGEDESC_TYPE_STRING)).head

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
@@ -19,7 +19,7 @@ package com.hortonworks.spark.atlas.types
 
 import com.google.common.collect.{ImmutableMap, ImmutableSet}
 import org.apache.atlas.AtlasConstants
-import org.apache.atlas.`type`.AtlasBuiltInTypes.{AtlasBooleanType, AtlasLongType, AtlasStringType}
+import org.apache.atlas.`type`.AtlasBuiltInTypes.{AtlasBooleanType, AtlasDateType, AtlasLongType, AtlasStringType}
 import org.apache.atlas.`type`.{AtlasArrayType, AtlasMapType, AtlasTypeUtil}
 import org.apache.atlas.model.typedef.AtlasStructDef.AtlasConstraintDef
 
@@ -44,11 +44,13 @@ object metadata {
     ImmutableSet.of("DataSet"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
       "qualifiedName", new AtlasStringType),
-    AtlasTypeUtil.createOptionalAttrDef(AtlasConstants.CLUSTER_NAME_ATTRIBUTE, new AtlasStringType),
+    AtlasTypeUtil.createRequiredAttrDef(AtlasConstants.CLUSTER_NAME_ATTRIBUTE, new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("description", new AtlasStringType),
-    AtlasTypeUtil.createOptionalAttrDef("locationUri", FS_PATH_TYPE_STRING),
+    AtlasTypeUtil.createOptionalAttrDef("location", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef(
-      "properties", new AtlasMapType(new AtlasStringType, new AtlasStringType)))
+      "parameters", new AtlasMapType(new AtlasStringType, new AtlasStringType)),
+    AtlasTypeUtil.createOptionalAttrDef(
+      "ownerType", new AtlasStringType))
 
   // ========= Storage description type =========
   val STORAGEDESC_TYPE = AtlasTypeUtil.createClassTypeDef(
@@ -58,13 +60,13 @@ object metadata {
     ImmutableSet.of("Referenceable"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
       "qualifiedName", new AtlasStringType),
-    AtlasTypeUtil.createOptionalAttrDef("locationUri", FS_PATH_TYPE_STRING),
+    AtlasTypeUtil.createOptionalAttrDef("location", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("inputFormat", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("outputFormat", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("serde", new AtlasStringType),
     AtlasTypeUtil.createRequiredAttrDef("compressed", new AtlasBooleanType),
     AtlasTypeUtil.createOptionalAttrDef(
-      "properties", new AtlasMapType(new AtlasStringType, new AtlasStringType)),
+      "parameters", new AtlasMapType(new AtlasStringType, new AtlasStringType)),
     AtlasTypeUtil.createOptionalAttrDefWithConstraint(
       "table",
       TABLE_TYPE_STRING,
@@ -82,11 +84,12 @@ object metadata {
     AtlasTypeUtil.createRequiredAttrDef("type", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("nullable", new AtlasBooleanType),
     AtlasTypeUtil.createOptionalAttrDef("metadata", new AtlasStringType),
+    AtlasTypeUtil.createOptionalAttrDef("comment", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDefWithConstraint(
       "table",
       TABLE_TYPE_STRING,
       AtlasConstraintDef.CONSTRAINT_TYPE_INVERSE_REF,
-      ImmutableMap.of(AtlasConstraintDef.CONSTRAINT_PARAM_ATTRIBUTE, "spark_schema")))
+      ImmutableMap.of(AtlasConstraintDef.CONSTRAINT_PARAM_ATTRIBUTE, "columns")))
 
   // ========= Table type =========
   val TABLE_TYPE = AtlasTypeUtil.createClassTypeDef(
@@ -101,7 +104,7 @@ object metadata {
     AtlasTypeUtil.createOptionalAttrDefWithConstraint(
       "sd", STORAGEDESC_TYPE_STRING, AtlasConstraintDef.CONSTRAINT_TYPE_OWNED_REF, null),
     AtlasTypeUtil.createOptionalAttrDefWithConstraint(
-      "spark_schema",
+      "columns",
       "array<spark_column>",
       AtlasConstraintDef.CONSTRAINT_TYPE_OWNED_REF, null),
     AtlasTypeUtil.createOptionalAttrDef("provider", new AtlasStringType),
@@ -111,12 +114,13 @@ object metadata {
       "bucketSpec", new AtlasMapType(new AtlasStringType, new AtlasStringType)),
     AtlasTypeUtil.createOptionalAttrDef("owner", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("ownerType", new AtlasStringType),
-    AtlasTypeUtil.createOptionalAttrDef("createTime", new AtlasLongType),
+    AtlasTypeUtil.createOptionalAttrDef("createTime", new AtlasDateType),
     AtlasTypeUtil.createOptionalAttrDef(
-      "properties", new AtlasMapType(new AtlasStringType, new AtlasStringType)),
+      "parameters", new AtlasMapType(new AtlasStringType, new AtlasStringType)),
     AtlasTypeUtil.createOptionalAttrDef("comment", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef(
-      "unsupportedFeatures", new AtlasArrayType(new AtlasStringType)))
+      "unsupportedFeatures", new AtlasArrayType(new AtlasStringType)),
+    AtlasTypeUtil.createOptionalAttrDef("viewOriginalText", new AtlasStringType))
 
   // ========= Process type =========
   val PROCESS_TYPE = AtlasTypeUtil.createClassTypeDef(

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/SparkAtlasEntityUtilsSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/SparkAtlasEntityUtilsSuite.scala
@@ -60,15 +60,11 @@ class SparkAtlasEntityUtilsSuite extends FunSuite with Matchers with BeforeAndAf
     val dbEntities = sparkAtlasEntityUtils.dbToEntities(dbDefinition)
 
     val dbEntity = dbEntities.head
-    val pathEntity = dbEntities.tail.head
     dbEntity.getTypeName should be (metadata.DB_TYPE_STRING)
     dbEntity.getAttribute("name") should be ("db1")
     dbEntity.getAttribute(AtlasConstants.CLUSTER_NAME_ATTRIBUTE) should be (
       AtlasConstants.DEFAULT_CLUSTER_NAME)
-    dbEntity.getAttribute("locationUri") should be (pathEntity)
-    pathEntity.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
-      "hdfs:///test/db/db1")
-    pathEntity.getAttribute(AtlasClient.NAME) should be ("/test/db/db1")
+    dbEntity.getAttribute("location") should be ("hdfs:///test/db/db1")
     dbEntity.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
       sparkSession.sparkContext.applicationId + ".db1")
   }
@@ -80,7 +76,7 @@ class SparkAtlasEntityUtilsSuite extends FunSuite with Matchers with BeforeAndAf
 
     val sdEntity = sdEntities.head
     sdEntity.getTypeName should be (metadata.STORAGEDESC_TYPE_STRING)
-    sdEntity.getAttribute("locationUri") should be (null)
+    sdEntity.getAttribute("location") should be (null)
     sdEntity.getAttribute("inputFormat") should be (null)
     sdEntity.getAttribute("outputFormat") should be (null)
     sdEntity.getAttribute("serde") should be (null)
@@ -131,7 +127,7 @@ class SparkAtlasEntityUtilsSuite extends FunSuite with Matchers with BeforeAndAf
     tableEntity.getAttribute("owner") should be (SparkUtils.currUser())
     tableEntity.getAttribute("ownerType") should be ("USER")
     tableEntity.getAttribute("sd") should be (sdEntity)
-    tableEntity.getAttribute("spark_schema") should be (schemaEntities.asJava)
+    tableEntity.getAttribute("columns") should be (schemaEntities.asJava)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes two major changes:

1. changes Spark catalog model definitions to accommodate existing Hive catalog model definitions
2. apply the changes into both Spark catalog entities and Hive metastore based catalog entities

Below is the excel sheet which compares existing Spark catalog model definitions and Hive catalog model definitions in Atlas's master branch. 
[SAC-168-table-models-description copy.xlsx](https://github.com/hortonworks-spark/spark-atlas-connector/files/3141841/SAC-168-table-models-description.copy.xlsx)

## How was this patch tested?

* Modified UTs.
* Manually tested against Spark 2.4 & Atlas 1.1

The differences are shown with CTAS query:

```
spark.range(10).write.json("/tmp/sac/json-sac-168-v2")
spark.sql("CREATE TABLE test_table_sac_168_v2_a USING json location '/tmp/sac/json-sac-168-v2'")
spark.sql("CREATE TABLE test_table_managed_sac_168_v2_a SELECT * FROM test_table_sac_168_v2_a")
```

```
scala> spark.sql("CREATE TABLE test_table_sac_168_v2_a USING json location '/tmp/sac/json-sac-168-v2'")
2019-05-03 21:53:43 WARN  HiveExternalCatalog:66 - Couldn't find corresponding Hive SerDe for data source provider json. Persisting data source table `default`.`test_table_sac_168_v2_a` into Hive metastore in Spark SQL specific format, which is NOT compatible with Hive.
scala> spark.sql("CREATE TABLE test_table_managed_sac_168_v2_a SELECT * FROM test_table_sac_168_v2_a")
2019-05-03 21:54:13 WARN  ObjectStore:568 - Failed to get database global_temp, returning NoSuchObjectException
2019-05-03 21:54:14 WARN  HiveMetaStore:1383 - Location: file:/WorkArea/Playground/spark-dist/releases/spark-2.4.0-bin-hadoop2.7/spark-warehouse/test_table_managed_sac_168_v2_a specified for non-external table:test_table_managed_sac_168_v2_a
```

entity | before | after
------ | ------ | ------
spark_db | <img width="897" alt="sac-168-v2-spark-db-before" src="https://user-images.githubusercontent.com/1317309/57141152-8c9c1d80-6df4-11e9-8473-a53daa6969c4.png"><br/><img width="777" alt="sac-168-v2-fs-path-warehouse-before" src="https://user-images.githubusercontent.com/1317309/57141328-e866a680-6df4-11e9-905a-756fed8115f9.png"> | <img width="1207" alt="sac-168-v2-spark-db-after" src="https://user-images.githubusercontent.com/1317309/57141135-7db56b00-6df4-11e9-90d1-cbfbb0e9aec5.png">
spark_table_external | <img width="901" alt="sac-168-v2-spark-table-external-before" src="https://user-images.githubusercontent.com/1317309/57141331-e8ff3d00-6df4-11e9-98b7-7776592ecb23.png"> | <img width="1210" alt="sac-168-v2-spark-table-external-after" src="https://user-images.githubusercontent.com/1317309/57141244-c10fd980-6df4-11e9-8d07-5852d5f85617.png">
spark_storagedesc_external | <img width="897" alt="sac-168-v2-spark-storagedesc-external-before" src="https://user-images.githubusercontent.com/1317309/57141329-e866a680-6df4-11e9-85d6-b2aad03c4fca.png"><br/><img width="897" alt="sac-168-v2-fs-path-source-path-before" src="https://user-images.githubusercontent.com/1317309/57141326-e866a680-6df4-11e9-99b1-eb0a693dc4c2.png"> | <img width="1212" alt="sac-168-v2-spark-storagedesc-external-after" src="https://user-images.githubusercontent.com/1317309/57141241-c0774300-6df4-11e9-85f9-0b0db84b1aae.png">
spark_table_managed | <img width="899" alt="sac-168-v2-spark-table-managed-before" src="https://user-images.githubusercontent.com/1317309/57141332-e8ff3d00-6df4-11e9-9305-0a8e7252ea7c.png"> | <img width="1209" alt="sac-168-v2-spark-table-managed-after" src="https://user-images.githubusercontent.com/1317309/57141245-c10fd980-6df4-11e9-9b28-bf5729449189.png">
spark_storagedesc_managed | <img width="897" alt="sac-168-v2-spark-storagedesc-managed-before" src="https://user-images.githubusercontent.com/1317309/57141330-e866a680-6df4-11e9-9356-c46e3571d98d.png"> | <img width="1210" alt="sac-168-v2-spark-storagedesc-managed-after" src="https://user-images.githubusercontent.com/1317309/57141243-c0774300-6df4-11e9-88b0-256ac6df26ae.png">

Look for the changes on column names/types, as well as the difference of information on storage desc in managed table.

Closes #168 