### PR TITLE
[SAC-229][SQL] Discard support of dropping table

### DIFF
--- a/spark-atlas-connector/src/test/resources/atlas-application.properties
+++ b/spark-atlas-connector/src/test/resources/atlas-application.properties
@@ -277,3 +277,6 @@ atlas.search.gremlin.enable=false
 #atlas.headers.Access-Control-Allow-Origin=*
 #atlas.headers.Access-Control-Allow-Methods=GET,OPTIONS,HEAD,PUT,POST
 #atlas.headers.<headerName>=<headerValue>
+
+atlas.client.username=admin
+atlas.client.password=admin

--- a/spark-atlas-connector/src/test/resources/atlas-application.properties
+++ b/spark-atlas-connector/src/test/resources/atlas-application.properties
@@ -277,6 +277,3 @@ atlas.search.gremlin.enable=false
 #atlas.headers.Access-Control-Allow-Origin=*
 #atlas.headers.Access-Control-Allow-Methods=GET,OPTIONS,HEAD,PUT,POST
 #atlas.headers.<headerName>=<headerValue>
-
-atlas.client.username=admin
-atlas.client.password=admin

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/BaseResourceIT.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/BaseResourceIT.scala
@@ -18,30 +18,35 @@
 package com.hortonworks.spark.atlas
 
 import scala.collection.JavaConverters._
-
 import com.sun.jersey.core.util.MultivaluedMapImpl
 import org.apache.atlas.AtlasClientV2
 import org.apache.atlas.model.SearchFilter
 import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.atlas.model.typedef.{AtlasStructDef, AtlasTypesDef}
 import org.apache.atlas.utils.AuthenticationUtil
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuite}
 
-abstract class BaseResourceIT extends FunSuite with BeforeAndAfterAll {
+abstract class BaseResourceIT extends FunSuite with BeforeAndAfterAll with BeforeAndAfterEach {
 
   protected var atlasUrls: Array[String] = null
   private var client: AtlasClientV2 = null
   protected val atlasClientConf = new AtlasClientConf
+  private var uniquePostfix: Long = 0
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-
 
     // set high timeouts so that tests do not fail due to read timeouts while you
     // are stepping through the code in a debugger
     atlasClientConf.set("atlas.client.readTimeoutMSecs", "100000000")
     atlasClientConf.set("atlas.client.connectTimeoutMSecs", "100000000")
     atlasUrls = Array(atlasClientConf.get(AtlasClientConf.ATLAS_REST_ENDPOINT))
+  }
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+
+    uniquePostfix = System.currentTimeMillis()
   }
 
   private def atlasClient(): AtlasClientV2 = {
@@ -92,7 +97,6 @@ abstract class BaseResourceIT extends FunSuite with BeforeAndAfterAll {
       .getEntity
   }
 
-
   protected def it(desc: String)(testFn: => Unit): Unit = {
     test(desc) {
       assume(
@@ -101,5 +105,9 @@ abstract class BaseResourceIT extends FunSuite with BeforeAndAfterAll {
           " is running")
       testFn
     }
+  }
+
+  protected def uniqueName(name: String): String = {
+    s"${name}_$uniquePostfix"
   }
 }

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CatalogEventToAtlasIT.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CatalogEventToAtlasIT.scala
@@ -57,37 +57,43 @@ class CatalogEventToAtlasIT extends BaseResourceIT with Matchers {
   }
 
   it("catalog db event to Atlas entities") {
+    val dbName = uniqueName("db1")
+
     // Create db entity in Atlas and make sure we get it from Atlas
     val tempDbPath = Files.createTempDirectory("db_")
-    val dbDefinition = createDB("db1", tempDbPath.normalize().toUri.toString)
+    val dbDefinition = createDB(dbName, tempDbPath.normalize().toUri.toString)
     SparkUtils.getExternalCatalog().createDatabase(dbDefinition, ignoreIfExists = true)
-    processor.pushEvent(CreateDatabaseEvent("db1"))
+    processor.pushEvent(CreateDatabaseEvent(dbName))
     eventually(timeout(30 seconds), interval(100 milliseconds)) {
-      val entity = getEntity(processor.dbType, processor.dbUniqueAttribute("db1"))
+      val entity = getEntity(processor.dbType, processor.dbUniqueAttribute(dbName))
       entity should not be (null)
-      entity.getAttribute("name") should be ("db1")
+      entity.getAttribute("name") should be (dbName)
       entity.getAttribute("owner") should be (SparkUtils.currUser())
       entity.getAttribute("ownerType") should be ("USER")
     }
 
     // Drop DB from external catalog to make sure we also delete the corresponding Atlas entity
-    SparkUtils.getExternalCatalog().dropDatabase("db1", ignoreIfNotExists = true, cascade = false)
-    processor.pushEvent(DropDatabaseEvent("db1"))
+    SparkUtils.getExternalCatalog().dropDatabase(dbName, ignoreIfNotExists = true, cascade = false)
+    processor.pushEvent(DropDatabaseEvent(dbName))
     eventually(timeout(30 seconds), interval(100 milliseconds)) {
       intercept[AtlasServiceException](
-        getEntity(processor.dbType, processor.dbUniqueAttribute("db1")))
+        getEntity(processor.dbType, processor.dbUniqueAttribute(dbName)))
     }
   }
 
   it("catalog table event to Atlas entities") {
+    val dbName = uniqueName("db2")
+    val tbl1Name = uniqueName("tbl1")
+    val tbl2Name = uniqueName("tbl2")
+
     val tempDbPath = Files.createTempDirectory("db_")
-    val dbDefinition = createDB("db2", tempDbPath.normalize().toUri.toString)
+    val dbDefinition = createDB(dbName, tempDbPath.normalize().toUri.toString)
     SparkUtils.getExternalCatalog().createDatabase(dbDefinition, ignoreIfExists = true)
-    processor.pushEvent(CreateDatabaseEvent("db2"))
+    processor.pushEvent(CreateDatabaseEvent(dbName))
     eventually(timeout(30 seconds), interval(100 milliseconds)) {
-      val entity = getEntity(processor.dbType, processor.dbUniqueAttribute("db2"))
+      val entity = getEntity(processor.dbType, processor.dbUniqueAttribute(dbName))
       entity should not be (null)
-      entity.getAttribute("name") should be ("db2")
+      entity.getAttribute("name") should be (dbName)
     }
 
     // Create new table
@@ -95,45 +101,47 @@ class CatalogEventToAtlasIT extends BaseResourceIT with Matchers {
       .add("user", StringType)
       .add("age", IntegerType)
     val sd = CatalogStorageFormat.empty
-    val tableDefinition = createTable("db2", "tbl1", schema, sd)
+    val tableDefinition = createTable(dbName, tbl1Name, schema, sd)
     val isHiveTbl = processor.isHiveTable(tableDefinition)
     SparkUtils.getExternalCatalog().createTable(tableDefinition, ignoreIfExists = true)
-    processor.pushEvent(CreateTableEvent("db2", "tbl1"))
+    processor.pushEvent(CreateTableEvent(dbName, tbl1Name))
 
     eventually(timeout(30 seconds), interval(100 milliseconds)) {
       val sdEntity = getEntity(processor.storageFormatType(isHiveTbl),
-        processor.storageFormatUniqueAttribute("db2", "tbl1", isHiveTbl))
+        processor.storageFormatUniqueAttribute(dbName, tbl1Name, isHiveTbl))
       sdEntity should not be (null)
 
       val tblEntity = getEntity(processor.tableType(isHiveTbl),
-        processor.tableUniqueAttribute("db2", "tbl1", isHiveTbl))
+        processor.tableUniqueAttribute(dbName, tbl1Name, isHiveTbl))
       tblEntity should not be (null)
-      tblEntity.getAttribute("name") should be ("tbl1")
+      tblEntity.getAttribute("name") should be (tbl1Name)
     }
 
     // Rename table
-    SparkUtils.getExternalCatalog().renameTable("db2", "tbl1", "tbl2")
-    processor.pushEvent(RenameTableEvent("db2", "tbl1", "tbl2"))
+    SparkUtils.getExternalCatalog().renameTable(dbName, tbl1Name, tbl2Name)
+    processor.pushEvent(RenameTableEvent(dbName, tbl1Name, tbl2Name))
     eventually(timeout(30 seconds), interval(100 milliseconds)) {
       val tblEntity = getEntity(processor.tableType(isHiveTbl),
-        processor.tableUniqueAttribute("db2", "tbl2", isHiveTbl))
+        processor.tableUniqueAttribute(dbName, tbl2Name, isHiveTbl))
       tblEntity should not be (null)
-      tblEntity.getAttribute("name") should be ("tbl2")
+      tblEntity.getAttribute("name") should be (tbl2Name)
 
       val sdEntity = getEntity(processor.storageFormatType(isHiveTbl),
-        processor.storageFormatUniqueAttribute("db2", "tbl2", isHiveTbl))
+        processor.storageFormatUniqueAttribute(dbName, tbl2Name, isHiveTbl))
       sdEntity should not be (null)
     }
 
     // Drop table
-    val tblDef2 = SparkUtils.getExternalCatalog().getTable("db2", "tbl2")
+    val tblDef2 = SparkUtils.getExternalCatalog().getTable(dbName, tbl2Name)
     val isHiveTbl2 = processor.isHiveTable(tblDef2)
-    processor.pushEvent(DropTablePreEvent("db2", "tbl2"))
-    processor.pushEvent(DropTableEvent("db2", "tbl2"))
+    processor.pushEvent(DropTablePreEvent(dbName, tbl2Name))
+    processor.pushEvent(DropTableEvent(dbName, tbl2Name))
 
-    eventually(timeout(30 seconds), interval(100 milliseconds)) {
-      intercept[AtlasServiceException](getEntity(processor.tableType(isHiveTbl),
-        processor.tableUniqueAttribute("db2", "tbl2", isHiveTbl2)))
-    }
+    // sleeping 2 secs - we have to do this to ensure there's no call on deletion, unfortunately...
+    Thread.sleep(2 * 1000)
+    // deletion request should not be added
+    val tblEntity = getEntity(processor.tableType(isHiveTbl),
+      processor.tableUniqueAttribute(dbName, tbl2Name, isHiveTbl2))
+    tblEntity should not be (null)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Please refer #229 to see the details of limitation which leads to discard existing feature.

This patch proposes to discard support dropping table, as the behavior cannot be consistent, and current approach is even error-prone.

## How was this patch tested?

Modified UTs and ITs. ITs ran with fresh Atlas 1.1.

This closes #229 