### PR TITLE
[SAC-231][CORE] Break down single "create entities" request into dependency first multiple requests

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasEntityReadHelper.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasEntityReadHelper.scala
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-package com.hortonworks.spark.atlas.sql.testhelper
+package com.hortonworks.spark.atlas
 
-import org.apache.atlas.model.instance.AtlasEntity
 import scala.collection.convert.Wrappers.SeqWrapper
+import org.apache.atlas.model.instance.{AtlasEntity, AtlasObjectId}
 
 object AtlasEntityReadHelper {
   def listAtlasEntitiesAsType(entities: Seq[AtlasEntity], typeStr: String): Seq[AtlasEntity] = {
@@ -33,8 +33,18 @@ object AtlasEntityReadHelper {
     filteredEntities.head
   }
 
-  def getOneEntityOnAttribute(entities: Seq[AtlasEntity], attrName: String, attrValue: String):
-  AtlasEntity = {
+  def getOnlyOneObjectId(objIds: Seq[AtlasObjectId], typeStr: String): AtlasObjectId = {
+    val filteredObjIds = objIds.filter { p =>
+      p.getTypeName.equals(typeStr)
+    }
+    assert(filteredObjIds.size == 1)
+    filteredObjIds.head
+  }
+
+  def getOnlyOneEntityOnAttribute(
+      entities: Seq[AtlasEntity],
+      attrName: String,
+      attrValue: String): AtlasEntity = {
     val filteredEntities = entities.filter { p =>
       p.getAttribute(attrName).equals(attrValue)
     }
@@ -46,12 +56,28 @@ object AtlasEntityReadHelper {
     entity.getAttribute(attrName).asInstanceOf[String]
   }
 
+  def getQualifiedName(entity: AtlasEntity): String = {
+    entity.getAttribute(org.apache.atlas.AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME)
+      .asInstanceOf[String]
+  }
+
   def getAtlasEntityAttribute(entity: AtlasEntity, attrName: String): AtlasEntity = {
     entity.getAttribute(attrName).asInstanceOf[AtlasEntity]
   }
 
-  def getSeqAtlasEntityAttribute(entity: AtlasEntity, attrName: String)
-  : Seq[AtlasEntity] = {
+  def getAtlasObjectIdAttribute(entity: AtlasEntity, attrName: String): AtlasObjectId = {
+    entity.getAttribute(attrName).asInstanceOf[AtlasObjectId]
+  }
+
+  def getSeqAtlasEntityAttribute(
+      entity: AtlasEntity,
+      attrName: String): Seq[AtlasEntity] = {
     entity.getAttribute(attrName).asInstanceOf[SeqWrapper[AtlasEntity]].underlying
+  }
+
+  def getSeqAtlasObjectIdAttribute(
+      entity: AtlasEntity,
+      attrName: String): Seq[AtlasObjectId] = {
+    entity.getAttribute(attrName).asInstanceOf[SeqWrapper[AtlasObjectId]].underlying
   }
 }

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasEntityWithDependencies.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasEntityWithDependencies.scala
@@ -15,10 +15,26 @@
  * limitations under the License.
  */
 
-package com.hortonworks.spark.atlas.sql
+package com.hortonworks.spark.atlas
 
-import com.hortonworks.spark.atlas.AtlasEntityWithDependencies
+import org.apache.atlas.model.instance.AtlasEntity
 
-trait Harvester[T] {
-  def harvest(node: T, qd: QueryDetail): Seq[AtlasEntityWithDependencies]
+class AtlasEntityWithDependencies(
+    val entity: AtlasEntity,
+    val dependencies: Seq[AtlasEntityWithDependencies]) {
+
+  def dependenciesAdded(deps: Seq[AtlasEntityWithDependencies]): AtlasEntityWithDependencies = {
+    new AtlasEntityWithDependencies(entity, dependencies ++ deps)
+  }
+}
+
+object AtlasEntityWithDependencies {
+  def apply(entity: AtlasEntity): AtlasEntityWithDependencies = {
+    new AtlasEntityWithDependencies(entity, Seq.empty)
+  }
+
+  def apply(entity: AtlasEntity, dependencies: Seq[AtlasEntity]): AtlasEntityWithDependencies = {
+    new AtlasEntityWithDependencies(entity,
+      dependencies.map(dep => new AtlasEntityWithDependencies(dep, Seq.empty)))
+  }
 }

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -21,7 +21,6 @@ import org.json4s.JsonAST.JObject
 import org.json4s.jackson.JsonMethods._
 
 import scala.util.Try
-import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
@@ -35,7 +34,7 @@ import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanExec, WriteToDataSourceV2Exec}
 import org.apache.spark.sql.execution.streaming.sources.MicroBatchWriter
 import org.apache.spark.sql.sources.v2.writer.DataSourceWriter
-import com.hortonworks.spark.atlas.AtlasClientConf
+import com.hortonworks.spark.atlas.{AtlasClientConf, AtlasEntityWithDependencies}
 import com.hortonworks.spark.atlas.sql.SparkExecutionPlanProcessor.SinkDataSourceWriter
 import com.hortonworks.spark.atlas.types.{AtlasEntityUtils, external, internal}
 import com.hortonworks.spark.atlas.utils.{Logging, SparkUtils}
@@ -46,85 +45,53 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
   override val conf: AtlasClientConf = new AtlasClientConf
 
   object InsertIntoHiveTableHarvester extends Harvester[InsertIntoHiveTable] {
-    override def harvest(node: InsertIntoHiveTable, qd: QueryDetail): Seq[AtlasEntity] = {
+    override def harvest(
+        node: InsertIntoHiveTable,
+        qd: QueryDetail): Seq[AtlasEntityWithDependencies] = {
       // source tables entities
-      val inputsEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
+      val inputEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
 
       // new table entity
-      val outputEntities = tableToEntities(node.table)
-      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
-      val outputTableEntities = List(outputEntities.head)
-      val logMap = getPlanInfo(qd)
+      val outputEntities = Seq(tableToEntity(node.table))
 
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputTablesEntities, outputEntities, logMap)
-      } else {
-        // create process entity
-        // Atlas doesn't support cycle here.
-        val cleanedOutput = cleanOutput(inputTablesEntities, outputTableEntities)
-        val pEntity = internal.etlProcessToEntity(
-          inputTablesEntities, cleanedOutput, logMap)
-        Seq(pEntity) ++ inputsEntities.flatten ++ cleanedOutput
-      }
+      makeProcessEntities(inputEntities, outputEntities, qd)
     }
   }
 
   object InsertIntoHadoopFsRelationHarvester extends Harvester[InsertIntoHadoopFsRelationCommand] {
-    override def harvest(node: InsertIntoHadoopFsRelationCommand, qd: QueryDetail)
-        : Seq[AtlasEntity] = {
+    override def harvest(
+        node: InsertIntoHadoopFsRelationCommand,
+        qd: QueryDetail): Seq[AtlasEntityWithDependencies] = {
       // source tables/files entities
-      val inputsEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
-      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
+      val inputEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
 
       // new table/file entity
-      val outputEntities = node.catalogTable.map(tableToEntities(_)).getOrElse(
-        external.pathToEntities(node.outputPath.toUri.toString))
-      val logMap = getPlanInfo(qd)
+      val outputEntities = Seq(node.catalogTable.map(tableToEntity(_)).getOrElse(
+        external.pathToEntity(node.outputPath.toUri.toString)))
 
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputTablesEntities, outputEntities, logMap)
-      } else {
-        val cleanedOutput = cleanOutput(inputTablesEntities, outputEntities)
-        val processEntity = internal.etlProcessToEntity(
-          inputTablesEntities, cleanedOutput.headOption.toList, logMap)
-        Seq(processEntity) ++ inputsEntities.flatten ++ cleanedOutput
-      }
+      makeProcessEntities(inputEntities, outputEntities, qd)
     }
   }
 
   object CreateHiveTableAsSelectHarvester extends Harvester[CreateHiveTableAsSelectCommand] {
     override def harvest(
         node: CreateHiveTableAsSelectCommand,
-        qd: QueryDetail): Seq[AtlasEntity] = {
+        qd: QueryDetail): Seq[AtlasEntityWithDependencies] = {
       // source tables entities
-      val inputsEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
+      val inputEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
 
       // new table entity
-      val outputEntities = tableToEntities(node.tableDesc.copy(owner = SparkUtils.currUser()))
+      val outputEntities = Seq(tableToEntity(node.tableDesc.copy(owner = SparkUtils.currUser())))
 
-      // create process entity
-      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
-      val outputTableEntities = List(outputEntities.head)
-      val logMap = getPlanInfo(qd)
-
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputTablesEntities, outputEntities, logMap)
-      } else {
-
-        // create process entity
-        val pEntity = internal.etlProcessToEntity(
-          inputTablesEntities, outputTableEntities, logMap)
-        Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
-      }
+      makeProcessEntities(inputEntities, outputEntities, qd)
     }
   }
 
   object CreateTableHarvester extends Harvester[CreateTableCommand] {
-    override def harvest(node: CreateTableCommand, qd: QueryDetail): Seq[AtlasEntity] = {
-      tableToEntities(node.table)
+    override def harvest(
+        node: CreateTableCommand,
+        qd: QueryDetail): Seq[AtlasEntityWithDependencies] = {
+      Seq(tableToEntity(node.table))
     }
   }
 
@@ -132,76 +99,48 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
     extends Harvester[CreateDataSourceTableAsSelectCommand] {
     override def harvest(
         node: CreateDataSourceTableAsSelectCommand,
-        qd: QueryDetail): Seq[AtlasEntity] = {
-      val inputsEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
-      val outputEntities = tableToEntities(node.table)
-      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
-      val outputTableEntities = List(outputEntities.head)
-      val logMap = getPlanInfo(qd)
+        qd: QueryDetail): Seq[AtlasEntityWithDependencies] = {
+      val inputEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
+      val outputEntities = Seq(tableToEntity(node.table))
 
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputTablesEntities, outputEntities, logMap)
-      } else {
-
-        // create process entity
-        val pEntity = internal.etlProcessToEntity(
-          inputTablesEntities, outputTableEntities, logMap)
-        Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
-      }
+      makeProcessEntities(inputEntities, outputEntities, qd)
     }
   }
 
   object LoadDataHarvester extends Harvester[LoadDataCommand] {
-    override def harvest(node: LoadDataCommand, qd: QueryDetail): Seq[AtlasEntity] = {
-      val pathEntities = external.pathToEntities(node.path)
-      val outputEntities = prepareEntities(node.table)
-      val logMap = getPlanInfo(qd)
+    override def harvest(
+        node: LoadDataCommand,
+        qd: QueryDetail): Seq[AtlasEntityWithDependencies] = {
+      val inputEntities = Seq(external.pathToEntity(node.path))
+      val outputEntities = Seq(prepareEntity(node.table))
 
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(pathEntities, outputEntities, logMap)
-      } else {
-
-        // create process entity
-        val pEntity = internal.etlProcessToEntity(
-          pathEntities.toList, List(outputEntities.head), logMap)
-        Seq(pEntity) ++ pathEntities ++ outputEntities
-      }
+      makeProcessEntities(inputEntities, outputEntities, qd)
     }
   }
 
   object InsertIntoHiveDirHarvester extends Harvester[InsertIntoHiveDirCommand] {
-    override def harvest(node: InsertIntoHiveDirCommand, qd: QueryDetail): Seq[AtlasEntity] = {
+    override def harvest(
+        node: InsertIntoHiveDirCommand,
+        qd: QueryDetail): Seq[AtlasEntityWithDependencies] = {
       if (node.storage.locationUri.isEmpty) {
         throw new IllegalStateException("Location URI is illegally empty")
       }
 
-      val destEntities = external.pathToEntities(node.storage.locationUri.get.toString)
-      val inputsEntities = discoverInputsEntities(qd.qe.sparkPlan, qd.qe.executedPlan)
+      val inputEntities = discoverInputsEntities(qd.qe.sparkPlan, qd.qe.executedPlan)
+      val outputEntities = Seq(external.pathToEntity(node.storage.locationUri.get.toString))
 
-      val inputs = inputsEntities.flatMap(_.headOption).toList
-      val logMap = getPlanInfo(qd)
-
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputs, destEntities, logMap)
-      } else {
-
-        // create process entity
-        val pEntity = internal.etlProcessToEntity(
-          inputs, destEntities.toList, logMap)
-        Seq(pEntity) ++ destEntities ++ inputsEntities.flatten
-      }
+      makeProcessEntities(inputEntities, outputEntities, qd)
     }
   }
 
   object CreateViewHarvester extends Harvester[CreateViewCommand] {
-    override def harvest(node: CreateViewCommand, qd: QueryDetail): Seq[AtlasEntity] = {
+    override def harvest(
+        node: CreateViewCommand,
+        qd: QueryDetail): Seq[AtlasEntityWithDependencies] = {
       // from table entities
       val child = node.child.asInstanceOf[Project].child
       val inputEntities = child match {
-        case r: UnresolvedRelation => prepareEntities(r.tableIdentifier)
+        case r: UnresolvedRelation => Seq(prepareEntity(r.tableIdentifier))
         case _: OneRowRelation => Seq.empty
         case n =>
           logWarn(s"Unknown leaf node: $n")
@@ -210,113 +149,62 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
 
       // new view entities
       val viewIdentifier = node.name
-      val outputEntities = prepareEntities(viewIdentifier)
+      val outputEntities = Seq(prepareEntity(viewIdentifier))
 
-      // create process entity
-      val inputTableEntity = inputEntities.headOption.toList
-      val outputTableEntity = List(outputEntities.head)
-      val logMap = getPlanInfo(qd)
-
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputTableEntity, outputTableEntity, logMap)
-      } else {
-
-        // create process entity
-        val pEntity = internal.etlProcessToEntity(
-          inputTableEntity, outputTableEntity, logMap)
-        Seq(pEntity) ++ inputEntities ++ outputEntities
-      }
+      makeProcessEntities(inputEntities, outputEntities, qd)
     }
   }
 
   object CreateDataSourceTableHarvester extends Harvester[CreateDataSourceTableCommand] {
-    override def harvest(node: CreateDataSourceTableCommand, qd: QueryDetail): Seq[AtlasEntity] = {
+    override def harvest(
+        node: CreateDataSourceTableCommand,
+        qd: QueryDetail): Seq[AtlasEntityWithDependencies] = {
       // only have table entities
-      tableToEntities(node.table)
+      Seq(tableToEntity(node.table))
     }
   }
 
   object SaveIntoDataSourceHarvester extends Harvester[SaveIntoDataSourceCommand] {
-    override def harvest(node: SaveIntoDataSourceCommand, qd: QueryDetail): Seq[AtlasEntity] = {
+    override def harvest(
+        node: SaveIntoDataSourceCommand,
+        qd: QueryDetail): Seq[AtlasEntityWithDependencies] = {
       // source table entity
-      val inputsEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
+      val inputEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
       val outputEntities = node match {
-        case SHCEntities(shcEntities) => shcEntities
-        case JDBCEntities(jdbcEntities) => jdbcEntities
-        case KafkaEntities(kafkaEntities) => kafkaEntities.headOption.getOrElse(Seq.empty)
+        case SHCEntities(shcEntities) => Seq(shcEntities)
+        case JDBCEntities(jdbcEntities) => Seq(jdbcEntities)
+        case KafkaEntities(kafkaEntities) => kafkaEntities
         case e =>
           logWarn(s"Missing output entities: $e")
           Seq.empty
       }
 
-      // create process entity
-      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
-      val outputTableEntities = outputEntities.toList
-      val logMap = getPlanInfo(qd)
-
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputTablesEntities, outputTableEntities, logMap)
-      } else {
-
-        // create process entity
-        val pEntity = internal.etlProcessToEntity(
-          inputTablesEntities, outputTableEntities, logMap)
-        Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
-      }
+      makeProcessEntities(inputEntities, outputEntities, qd)
     }
   }
 
   object WriteToDataSourceV2Harvester extends Harvester[WriteToDataSourceV2Exec] {
-    override def harvest(node: WriteToDataSourceV2Exec, qd: QueryDetail): Seq[AtlasEntity] = {
-      val sinkEntities = node.writer match {
+    override def harvest(
+        node: WriteToDataSourceV2Exec,
+        qd: QueryDetail): Seq[AtlasEntityWithDependencies] = {
+      val inputEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
+
+      val outputEntities = node.writer match {
         case w: MicroBatchWriter if w.writer.isInstanceOf[SinkDataSourceWriter] =>
           discoverOutputEntities(w.writer.asInstanceOf[SinkDataSourceWriter].sinkProgress)
 
         case w => discoverOutputEntities(w)
       }
 
-      val sourceEntities = discoverInputsEntities(node.query, qd.qe.executedPlan)
-
-      makeProcessEntities(sourceEntities.flatten, sinkEntities, makeLogMap(qd))
-    }
-
-    private def makeLogMap(qd: QueryDetail): Map[String, String] = {
-      // create process entity
-      Map(
-        "executionId" -> qd.executionId.toString,
-        "remoteUser" -> SparkUtils.currSessionUser(qd.qe),
-        "executionTime" -> qd.executionTime.toString,
-        "details" -> qd.qe.toString(),
-        "sparkPlanDescription" -> qd.qe.sparkPlan.toString())
-    }
-
-    private def makeProcessEntities(
-        inputsEntities: Seq[AtlasEntity],
-        outputEntities: Seq[AtlasEntity],
-        logMap: Map[String, String]): Seq[AtlasEntity] = {
-      val inputTablesEntities = inputsEntities.toList
-      val outputTableEntities = outputEntities.toList
-
-      // ml related cached object
-      if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputTablesEntities, outputEntities, logMap)
-      } else {
-        // create process entity
-        val pEntity = internal.etlProcessToEntity(
-          inputTablesEntities, outputTableEntities, logMap)
-
-        Seq(pEntity) ++ inputsEntities ++ outputEntities
-      }
+      makeProcessEntities(inputEntities, outputEntities, qd)
     }
   }
 
-  def prepareEntities(tableIdentifier: TableIdentifier): Seq[AtlasEntity] = {
+  def prepareEntity(tableIdentifier: TableIdentifier): AtlasEntityWithDependencies = {
     val tableName = tableIdentifier.table
     val dbName = tableIdentifier.database.getOrElse("default")
     val tableDef = SparkUtils.getExternalCatalog().getTable(dbName, tableName)
-    tableToEntities(tableDef)
+    tableToEntity(tableDef)
   }
 
   private def getPlanInfo(qd: QueryDetail): Map[String, String] = {
@@ -327,21 +215,33 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       "sparkPlanDescription" -> qd.qe.sparkPlan.toString())
   }
 
+  private def makeProcessEntities(
+      inputsEntities: Seq[AtlasEntityWithDependencies],
+      outputEntities: Seq[AtlasEntityWithDependencies],
+      qd: QueryDetail): Seq[AtlasEntityWithDependencies] = {
+    val logMap = getPlanInfo(qd)
+
+    val cleanedOutput = cleanOutput(inputsEntities, outputEntities)
+
+    // ml related cached object
+    if (internal.cachedObjects.contains("model_uid")) {
+      Seq(internal.updateMLProcessToEntity(inputsEntities, cleanedOutput, logMap))
+    } else {
+      // create process entity
+      Seq(internal.etlProcessToEntity(inputsEntities, cleanedOutput, logMap))
+    }
+  }
+
   private def discoverInputsEntities(
       plan: LogicalPlan,
-      executedPlan: SparkPlan): Seq[Seq[AtlasEntity]] = {
+      executedPlan: SparkPlan): Seq[AtlasEntityWithDependencies] = {
     val tChildren = plan.collectLeaves()
-    // NOTE: Each element in output should be Sequence which first element represents
-    // actual input entity (rest entities can be dependencies of input entity).
-    // If multiple inputs are extracted from one Relation, they should be provided like
-    // Seq(Seq(entities for first), Seq(entities for second), ...)
-
     tChildren.flatMap {
-      case r: HiveTableRelation => Seq(tableToEntities(r.tableMeta))
-      case v: View => Seq(tableToEntities(v.desc))
+      case r: HiveTableRelation => Seq(tableToEntity(r.tableMeta))
+      case v: View => Seq(tableToEntity(v.desc))
       case LogicalRelation(fileRelation: FileRelation, _, catalogTable, _) =>
-        catalogTable.map(tbl => Seq(tableToEntities(tbl))).getOrElse(
-          fileRelation.inputFiles.flatMap(file => Seq(external.pathToEntities(file))).toSeq)
+        catalogTable.map(tbl => Seq(tableToEntity(tbl))).getOrElse(
+          fileRelation.inputFiles.flatMap(file => Seq(external.pathToEntity(file))).toSeq)
       case SHCEntities(shcEntities) => Seq(shcEntities)
       case HWCEntities(hwcEntities) => Seq(hwcEntities)
       case JDBCEntities(jdbcEntities) => Seq(jdbcEntities)
@@ -354,24 +254,19 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
 
   private def discoverInputsEntities(
       sparkPlan: SparkPlan,
-      executedPlan: SparkPlan): Seq[Seq[AtlasEntity]] = {
-    // NOTE: Each element in output should be Sequence which first element represents
-    // actual input entity (rest entities can be dependencies of input entity).
-    // If multiple inputs are extracted from one Relation, they should be provided like
-    // Seq(Seq(entities for first), Seq(entities for second), ...)
-
+      executedPlan: SparkPlan): Seq[AtlasEntityWithDependencies] = {
     sparkPlan.collectLeaves().flatMap {
       case h if h.getClass.getName == "org.apache.spark.sql.hive.execution.HiveTableScanExec" =>
         Try {
           val method = h.getClass.getMethod("relation")
           method.setAccessible(true)
           val relation = method.invoke(h).asInstanceOf[HiveTableRelation]
-          Seq(tableToEntities(relation.tableMeta))
+          Seq(tableToEntity(relation.tableMeta))
         }.getOrElse(Seq.empty)
 
       case f: FileSourceScanExec =>
-        f.tableIdentifier.map(tbl => Seq(prepareEntities(tbl))).getOrElse(
-          f.relation.location.inputFiles.flatMap(file => Seq(external.pathToEntities(file))).toSeq)
+        f.tableIdentifier.map(tbl => Seq(prepareEntity(tbl))).getOrElse(
+          f.relation.location.inputFiles.flatMap(file => Seq(external.pathToEntity(file))).toSeq)
       case SHCEntities(shcEntities) => Seq(shcEntities)
       case HWCEntities(hwcEntities) => Seq(hwcEntities)
       case JDBCEntities(jdbcEntities) => Seq(jdbcEntities)
@@ -382,13 +277,13 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
     }
   }
 
-  private def discoverOutputEntities(sink: SinkProgress): Seq[AtlasEntity] = {
+  private def discoverOutputEntities(sink: SinkProgress): Seq[AtlasEntityWithDependencies] = {
     if (sink.description.contains("FileSink")) {
       val begin = sink.description.indexOf('[')
       val end = sink.description.indexOf(']')
       val path = sink.description.substring(begin + 1, end)
       logDebug(s"record the streaming query sink output path information $path")
-      external.pathToEntities(path)
+      Seq(external.pathToEntity(path))
     } else if (sink.description.contains("ConsoleSinkProvider")) {
       logInfo(s"do not track the console output as Atlas entity ${sink.description}")
       Seq.empty
@@ -397,10 +292,10 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
     }
   }
 
-  private def discoverOutputEntities(writer: DataSourceWriter): Seq[AtlasEntity] = {
+  private def discoverOutputEntities(writer: DataSourceWriter): Seq[AtlasEntityWithDependencies] = {
     writer match {
-      case HWCEntities(hwcEntities) => hwcEntities
-      case KafkaEntities(kafkaEntities) => kafkaEntities
+      case HWCEntities(hwcEntities) => Seq(hwcEntities)
+      case KafkaEntities(kafkaEntities) => Seq(kafkaEntities)
       case e =>
         logWarn(s"Missing unknown leaf node: $e")
         Seq.empty
@@ -408,26 +303,27 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
   }
 
   object HWCHarvester extends Harvester[WriteToDataSourceV2Exec] {
-    override def harvest(node: WriteToDataSourceV2Exec, qd: QueryDetail): Seq[AtlasEntity] = {
+    override def harvest(
+        node: WriteToDataSourceV2Exec,
+        qd: QueryDetail): Seq[AtlasEntityWithDependencies] = {
       // Source table entity
       val inputsEntities = discoverInputsEntities(qd.qe.sparkPlan, qd.qe.executedPlan)
 
       // Supports Spark HWC (destination table entity)
-      val outputEntities = HWCEntities.getHWCEntity(node.writer)
+      val outputEntities = HWCEntities.getHWCEntity(node.writer) match {
+        case Some(entity) => Seq(entity)
+        case None => Seq.empty
+      }
 
       // Creates process entity
-      val inputTablesEntities = inputsEntities.flatMap(_.headOption).toList
-      val outputTableEntities = outputEntities.toList
       val logMap = getPlanInfo(qd)
 
       // ML related cached object
       if (internal.cachedObjects.contains("model_uid")) {
-        internal.updateMLProcessToEntity(inputTablesEntities, outputTableEntities, logMap)
+        Seq(internal.updateMLProcessToEntity(inputsEntities, outputEntities, logMap))
       } else {
         // Creates process entity
-        val pEntity = internal.etlProcessToEntity(
-          inputTablesEntities, outputTableEntities, logMap)
-        Seq(pEntity) ++ inputsEntities.flatten ++ outputEntities
+        Seq(internal.etlProcessToEntity(inputsEntities, outputEntities, logMap))
       }
     }
   }
@@ -466,18 +362,16 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       val STREAM_WRITE =
         "com.hortonworks.spark.sql.hive.llap.streaming.HiveStreamingDataSourceWriter"
 
-      def extractFromWriter(writer: DataSourceWriter): Option[Seq[AtlasEntity]] = writer match {
+      def extractFromWriter(
+          writer: DataSourceWriter): Option[AtlasEntityWithDependencies] = writer match {
         case w: DataSourceWriter
-          if w.getClass.getCanonicalName.endsWith(BATCH_WRITE) =>
-          Some(getHWCEntity(w))
+          if w.getClass.getCanonicalName.endsWith(BATCH_WRITE) => getHWCEntity(w)
 
         case w: DataSourceWriter
-          if w.getClass.getCanonicalName.endsWith(BATCH_STREAM_WRITE) =>
-          Some(getHWCEntity(w))
+          if w.getClass.getCanonicalName.endsWith(BATCH_STREAM_WRITE) => getHWCEntity(w)
 
         case w: DataSourceWriter
-          if w.getClass.getCanonicalName.endsWith(STREAM_WRITE) =>
-          Some(getHWCEntity(w))
+          if w.getClass.getCanonicalName.endsWith(STREAM_WRITE) => getHWCEntity(w)
 
         case w: MicroBatchWriter
           if w.getClass.getMethod("writer").invoke(w)
@@ -489,25 +383,25 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       }
     }
 
-    def unapply(plan: LogicalPlan): Option[Seq[AtlasEntity]] = plan match {
+    def unapply(plan: LogicalPlan): Option[AtlasEntityWithDependencies] = plan match {
       case ds: DataSourceV2Relation
           if ds.source.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_READ_SOURCE) =>
-        Some(getHWCEntity(ds.options))
+        getHWCEntity(ds.options)
       case _ => None
     }
 
-    def unapply(plan: SparkPlan): Option[Seq[AtlasEntity]] = plan match {
+    def unapply(plan: SparkPlan): Option[AtlasEntityWithDependencies] = plan match {
       case ds: DataSourceV2ScanExec
           if ds.source.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_READ_SOURCE) =>
-        Some(getHWCEntity(ds.options))
+        getHWCEntity(ds.options)
       case _ => None
     }
 
-    def unapply(writer: DataSourceWriter): Option[Seq[AtlasEntity]] = {
+    def unapply(writer: DataSourceWriter): Option[AtlasEntityWithDependencies] = {
       HWCSupport.extractFromWriter(writer)
     }
 
-    def getHWCEntity(options: Map[String, String]): Seq[AtlasEntity] = {
+    def getHWCEntity(options: Map[String, String]): Option[AtlasEntityWithDependencies] = {
       if (options.contains("query")) {
         val sql = options("query")
         // HACK ALERT! Currently SAC and HWC only know the query that has to be pushed down
@@ -520,27 +414,27 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
             val db = r.tableIdentifier.database.getOrElse(
               options.getOrElse("default.db", "default"))
             val tableName = r.tableIdentifier.table
-            external.hwcTableToEntities(db, tableName, clusterName)
+            Seq(external.hwcTableToEntity(db, tableName, clusterName))
           case _: OneRowRelation => Seq.empty
           case n =>
             logWarn(s"Unknown leaf node: $n")
             Seq.empty
-        }
+        }.headOption
       } else {
         val (db, tableName) = getDbTableNames(
           options.getOrElse("default.db", "default"), options.getOrElse("table", ""))
-        external.hwcTableToEntities(db, tableName, clusterName)
+        Some(external.hwcTableToEntity(db, tableName, clusterName))
       }
     }
 
-    def getHWCEntity(r: DataSourceWriter): Seq[AtlasEntity] = r match {
+    def getHWCEntity(r: DataSourceWriter): Option[AtlasEntityWithDependencies] = r match {
       case _ if r.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_WRITE) =>
         val f = r.getClass.getDeclaredField("options")
         f.setAccessible(true)
         val options = f.get(r).asInstanceOf[java.util.Map[String, String]]
         val (db, tableName) = getDbTableNames(
           options.getOrDefault("default.db", "default"), options.getOrDefault("table", ""))
-        external.hwcTableToEntities(db, tableName, clusterName)
+        Some(external.hwcTableToEntity(db, tableName, clusterName))
 
       case _ if r.getClass.getCanonicalName.endsWith(HWCSupport.BATCH_STREAM_WRITE) =>
         val dbField = r.getClass.getDeclaredField("db")
@@ -551,7 +445,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
         tableField.setAccessible(true)
         val table = tableField.get(r).asInstanceOf[String]
 
-        external.hwcTableToEntities(db, table, clusterName)
+        Some(external.hwcTableToEntity(db, table, clusterName))
 
       case _ if r.getClass.getCanonicalName.endsWith(HWCSupport.STREAM_WRITE) =>
         val dbField = r.getClass.getDeclaredField("db")
@@ -562,14 +456,14 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
         tableField.setAccessible(true)
         val table = tableField.get(r).asInstanceOf[String]
 
-        external.hwcTableToEntities(db, table, clusterName)
+        Some(external.hwcTableToEntity(db, table, clusterName))
 
       case w: MicroBatchWriter
           if w.getClass.getMethod("writer").invoke(w)
             .getClass.toString.endsWith(HWCSupport.STREAM_WRITE) =>
         getHWCEntity(w.getClass.getMethod("writer").invoke(w).asInstanceOf[DataSourceWriter])
 
-      case _ => Seq.empty
+      case _ => None
     }
 
     // This logic was ported from HWC's `SchemaUtil.getDbTableNames`
@@ -596,30 +490,30 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
     private val RELATION_PROVIDER_CLASS_NAME =
       "org.apache.spark.sql.execution.datasources.hbase.DefaultSource"
 
-    def unapply(plan: LogicalPlan): Option[Seq[AtlasEntity]] = plan match {
+    def unapply(plan: LogicalPlan): Option[AtlasEntityWithDependencies] = plan match {
       case l: LogicalRelation
         if l.relation.getClass.getCanonicalName.endsWith(SHC_RELATION_CLASS_NAME) =>
         val baseRelation = l.relation.asInstanceOf[BaseRelation]
         val options = baseRelation.getClass.getMethod("parameters")
           .invoke(baseRelation).asInstanceOf[Map[String, String]]
-        Some(getSHCEntity(options))
+        getSHCEntity(options)
       case sids: SaveIntoDataSourceCommand
         if sids.dataSource.getClass.getCanonicalName.endsWith(RELATION_PROVIDER_CLASS_NAME) =>
-        Some(getSHCEntity(sids.options))
+        getSHCEntity(sids.options)
       case _ => None
     }
 
-    def unapply(plan: SparkPlan): Option[Seq[AtlasEntity]] = plan match {
+    def unapply(plan: SparkPlan): Option[AtlasEntityWithDependencies] = plan match {
       case r: RowDataSourceScanExec
         if r.relation.getClass.getCanonicalName.endsWith(SHC_RELATION_CLASS_NAME) =>
         val baseRelation = r.relation.asInstanceOf[BaseRelation]
         val options = baseRelation.getClass.getMethod("parameters")
           .invoke(baseRelation).asInstanceOf[Map[String, String]]
-        Some(getSHCEntity(options))
+        getSHCEntity(options)
       case _ => None
     }
 
-    def getSHCEntity(options: Map[String, String]): Seq[AtlasEntity] = {
+    def getSHCEntity(options: Map[String, String]): Option[AtlasEntityWithDependencies] = {
       if (options.getOrElse("catalog", "") != "") {
         val catalog = options("catalog")
         val cluster = options.getOrElse(AtlasClientConf.CLUSTER_NAME.key, clusterName)
@@ -629,16 +523,16 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
         // `asInstanceOf` is required. Otherwise, it fails compilation.
         val nSpace = tableMeta.getOrElse("namespace", "default").asInstanceOf[String]
         val tName = tableMeta("name").asInstanceOf[String]
-        external.hbaseTableToEntity(cluster, tName, nSpace)
+        Some(external.hbaseTableToEntity(cluster, tName, nSpace))
       } else {
-        Seq.empty[AtlasEntity]
+        None
       }
     }
   }
 
   object KafkaEntities {
     private def convertTopicsToEntities(
-        topics: Set[KafkaTopicInformation]): Option[Seq[Seq[AtlasEntity]]] = {
+        topics: Set[KafkaTopicInformation]): Option[Seq[AtlasEntityWithDependencies]] = {
       if (topics.nonEmpty) {
         Some(topics.map(external.kafkaToEntity(clusterName, _)).toSeq)
       } else {
@@ -646,17 +540,17 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       }
     }
 
-    def unapply(plan: LogicalPlan): Option[Seq[Seq[AtlasEntity]]] = plan match {
+    def unapply(plan: LogicalPlan): Option[Seq[AtlasEntityWithDependencies]] = plan match {
       case l: LogicalRelation if ExtractFromDataSource.isKafkaRelation(l.relation) =>
         val topics = ExtractFromDataSource.extractSourceTopicsFromKafkaRelation(l.relation)
         Some(topics.map(external.kafkaToEntity(clusterName, _)).toSeq)
       case sids: SaveIntoDataSourceCommand
         if ExtractFromDataSource.isKafkaRelationProvider(sids.dataSource) =>
-        Some(Seq(getKafkaEntity(sids.options)))
+        getKafkaEntity(sids.options).map(Seq(_))
       case _ => None
     }
 
-    def unapply(plan: SparkPlan): Option[Seq[Seq[AtlasEntity]]] = {
+    def unapply(plan: SparkPlan): Option[Seq[AtlasEntityWithDependencies]] = {
       val topics = plan match {
         case r: RowDataSourceScanExec =>
           ExtractFromDataSource.extractSourceTopicsFromKafkaRelation(r.relation)
@@ -670,7 +564,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       convertTopicsToEntities(topics)
     }
 
-    def unapply(r: DataSourceWriter): Option[Seq[AtlasEntity]] = r match {
+    def unapply(r: DataSourceWriter): Option[AtlasEntityWithDependencies] = r match {
       case writer: MicroBatchWriter => ExtractFromDataSource.extractTopic(writer) match {
         case Some(topicInformation) => Some(external.kafkaToEntity(clusterName, topicInformation))
         case _ => None
@@ -679,16 +573,16 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       case _ => None
     }
 
-    def getKafkaEntity(options: Map[String, String]): Seq[AtlasEntity] = {
+    def getKafkaEntity(options: Map[String, String]): Option[AtlasEntityWithDependencies] = {
       options.get("topic") match {
         case Some(topic) =>
           val cluster = options.get("kafka." + AtlasClientConf.CLUSTER_NAME.key)
-          external.kafkaToEntity(clusterName, KafkaTopicInformation(topic, cluster))
+          Some(external.kafkaToEntity(clusterName, KafkaTopicInformation(topic, cluster)))
 
         case _ =>
           // output topic not specified: maybe each output row contains target topic name
           // giving up
-          Seq.empty[AtlasEntity]
+          None
       }
     }
   }
@@ -700,7 +594,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
     private val JDBC_PROVIDER_CLASS_NAME =
       "org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider"
 
-    def unapply(plan: LogicalPlan): Option[Seq[AtlasEntity]] = plan match {
+    def unapply(plan: LogicalPlan): Option[AtlasEntityWithDependencies] = plan match {
       case l: LogicalRelation
         if l.relation.getClass.getCanonicalName.endsWith(JDBC_RELATION_CLASS_NAME) =>
         val baseRelation = l.relation.asInstanceOf[BaseRelation]
@@ -713,7 +607,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       case _ => None
     }
 
-    def unapply(plan: SparkPlan): Option[Seq[AtlasEntity]] = plan match {
+    def unapply(plan: SparkPlan): Option[AtlasEntityWithDependencies] = plan match {
       case r: RowDataSourceScanExec
         if r.relation.getClass.getCanonicalName.endsWith(JDBC_PROVIDER_CLASS_NAME) =>
         val baseRelation = r.relation.asInstanceOf[BaseRelation]
@@ -723,7 +617,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
       case _ => None
     }
 
-    private def getJdbcEnity(options: Map[String, String]) : Seq[AtlasEntity] = {
+    private def getJdbcEnity(options: Map[String, String]): AtlasEntityWithDependencies = {
       val url = options.getOrElse("url", "")
       val tableName = options.getOrElse("dbtable", "")
       external.rdbmsTableToEntity(url, tableName)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
@@ -20,8 +20,6 @@ package com.hortonworks.spark.atlas.sql
 import com.hortonworks.spark.atlas.sql.CommandsHarvester.WriteToDataSourceV2Harvester
 import com.hortonworks.spark.atlas.sql.SparkExecutionPlanProcessor.SinkDataSourceWriter
 
-import scala.collection.convert.Wrappers.SeqWrapper
-import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.execution.datasources.{InsertIntoHadoopFsRelationCommand, SaveIntoDataSourceCommand}
@@ -30,7 +28,6 @@ import org.apache.spark.sql.execution.streaming.sources.MicroBatchWriter
 import org.apache.spark.sql.hive.execution._
 import org.apache.spark.sql.sources.v2.writer.{DataWriterFactory, WriterCommitMessage}
 import com.hortonworks.spark.atlas.{AbstractEventProcessor, AtlasClient, AtlasClientConf}
-import com.hortonworks.spark.atlas.types.{external, metadata}
 import com.hortonworks.spark.atlas.utils.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.sources.v2.writer.streaming.StreamWriter
@@ -142,7 +139,7 @@ class SparkExecutionPlanProcessor(
         }
       }
 
-      atlasClient.createEntities(entities)
+      atlasClient.createEntitiesWithDependencies(entities)
       logDebug(s"Created entities without columns")
   }
 }

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/TestUtils.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/TestUtils.scala
@@ -22,8 +22,8 @@ import java.net.URI
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogStorageFormat, CatalogTable, CatalogTableType}
 import org.apache.spark.sql.types.StructType
-
 import com.hortonworks.spark.atlas.utils.SparkUtils
+import org.apache.atlas.model.instance.AtlasObjectId
 
 object TestUtils {
   def createDB(name: String, location: String): CatalogDatabase = {
@@ -58,5 +58,21 @@ object TestUtils {
 
   def assertSubsetOf[T](set: Set[T], subset: Set[T]): Unit = {
     assert(subset.subsetOf(set), s"$subset is not a subset of $set")
+  }
+
+  def findEntity(
+      entities: Seq[AtlasEntityWithDependencies],
+      objId: AtlasObjectId): Option[AtlasEntityWithDependencies] = {
+    entities.find { p =>
+      AtlasUtils.entityToReference(p.entity) == objId
+    }
+  }
+
+  def findEntities(
+      entities: Seq[AtlasEntityWithDependencies],
+      objIds: Seq[AtlasObjectId]): Seq[AtlasEntityWithDependencies] = {
+    entities.filter { p =>
+      objIds.contains(AtlasUtils.entityToReference(p.entity))
+    }
   }
 }

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateDataSourceTableAsSelectHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateDataSourceTableAsSelectHarvesterSuite.scala
@@ -70,7 +70,8 @@ class CreateDataSourceTableAsSelectHarvesterSuite
 
     val qd = QueryDetail(df.queryExecution, 0L, 0L)
     val entities = CommandsHarvester.CreateDataSourceTableAsSelectHarvester.harvest(cmd, qd)
-    val maybeEntity = entities.find(e => e.getTypeName == "spark_table")
+    val processDeps = entities.head.dependencies
+    val maybeEntity = processDeps.find(e => e.entity.getTypeName == "spark_table").map(_.entity)
 
     assert(maybeEntity.isDefined, s"Output entity for table [$destTblName] was not found.")
     assert(maybeEntity.get.getAttribute("name") == destTblName)

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateViewHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateViewHarvesterSuite.scala
@@ -19,42 +19,25 @@ package com.hortonworks.spark.atlas.sql
 
 import java.util
 
-import com.hortonworks.spark.atlas.sql.testhelper.AtlasEntityReadHelper._
-
 import scala.collection.JavaConverters._
 import scala.util.Random
 import org.apache.atlas.AtlasClient
-import org.apache.atlas.model.instance.AtlasEntity
+import org.apache.atlas.model.instance.AtlasObjectId
 import org.apache.spark.sql.execution.command.{CreateViewCommand, ExecutedCommandExec}
 import org.scalatest.{FunSuite, Matchers}
-import com.hortonworks.spark.atlas.types.{external, metadata}
-import com.hortonworks.spark.atlas.{AtlasClientConf, WithHiveSupport}
-import com.hortonworks.spark.atlas.sql.testhelper.{AtlasQueryExecutionListener, CreateEntitiesTrackingAtlasClient, DirectProcessSparkExecutionPlanProcessor}
-
+import com.hortonworks.spark.atlas.types.external
+import com.hortonworks.spark.atlas._
 
 class CreateViewHarvesterSuite extends FunSuite with Matchers with WithHiveSupport {
   private val sourceTblName = "source_" + Random.nextInt(100000)
   private val destinationViewName = "destination_" + Random.nextInt(100000)
   private val destinationViewName2 = "destination_" + Random.nextInt(100000)
-  private val destinationViewName3 = "destination_" + Random.nextInt(100000)
-  private val destinationTableName = "destination_" + Random.nextInt(100000)
-
-  private val testHelperQueryListener = new AtlasQueryExecutionListener()
-
-  var atlasClient: CreateEntitiesTrackingAtlasClient = _
-  val atlasClientConf: AtlasClientConf = new AtlasClientConf()
-    .set(AtlasClientConf.CHECK_MODEL_IN_START.key, "false")
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
 
     sparkSession.sql(s"CREATE TABLE $sourceTblName (name string)")
     sparkSession.sql(s"INSERT INTO TABLE $sourceTblName VALUES ('lucy'), ('tom')")
-
-    // setup Atlas client
-    testHelperQueryListener.clear()
-    atlasClient = new CreateEntitiesTrackingAtlasClient()
-    sparkSession.listenerManager.register(testHelperQueryListener)
   }
 
   test("CREATE VIEW FROM TABLE") {
@@ -68,25 +51,30 @@ class CreateViewHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
     val cmd = node.cmd.asInstanceOf[CreateViewCommand]
 
     val entities = CommandsHarvester.CreateViewHarvester.harvest(cmd, qd)
-    val pEntity = entities.head
+    val pEntity = entities.head.entity
 
     assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
-    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
+    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasObjectId]]
     inputs.size() should be (1)
 
     val inputTbl = inputs.asScala.head
-    inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
-    inputTbl.getAttribute("name") should be (sourceTblName)
-    inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should be (
+    val inputEntity = TestUtils.findEntity(entities.head.dependencies, inputTbl).get
+
+    inputEntity.entity.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+    inputEntity.entity.getAttribute("name") should be (sourceTblName)
+    inputEntity.entity.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should be (
       s"default.$sourceTblName@primary")
 
     assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
-    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
+    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasObjectId]]
     outputs.size() should be (1)
+
     val outputView = outputs.asScala.head
-    outputView.getAttribute("name") should be (destinationViewName)
-    outputView.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
-      s"default.$destinationViewName")
+    val outputEntity = TestUtils.findEntity(entities.head.dependencies, outputView).get
+
+    outputEntity.entity.getAttribute("name") should be (destinationViewName)
+    outputEntity.entity.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should
+      endWith (s"default.$destinationViewName")
   }
 
   test("CREATE VIEW without source") {
@@ -100,66 +88,20 @@ class CreateViewHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
     val cmd = node.cmd.asInstanceOf[CreateViewCommand]
 
     val entities = CommandsHarvester.CreateViewHarvester.harvest(cmd, qd)
-    val pEntity = entities.head
+    val pEntity = entities.head.entity
     assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
-    assert(pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]].size() == 0)
+    assert(pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasObjectId]].size() == 0)
 
     assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
-    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
+    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasObjectId]]
     outputs.size() should be (1)
+
     val outputView = outputs.asScala.head
-    outputView.getAttribute("name") should be (destinationViewName2)
-    outputView.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
-      s"default.$destinationViewName2")
-  }
+    val outputEntity = TestUtils.findEntity(entities.head.dependencies, outputView).get
 
-  test("CREATE TEMPORARY VIEW FROM TABLE, SAVE TEMP VIEW TO TABLE") {
-    val planProcessor = new DirectProcessSparkExecutionPlanProcessor(atlasClient, atlasClientConf)
-    sparkSession.sql(s"SELECT * FROM $sourceTblName").createOrReplaceTempView(destinationViewName3)
+    outputView.getUniqueAttributes.get(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should
+      endWith (s"default.$destinationViewName2")
 
-    var queryDetail = testHelperQueryListener.queryDetails.last
-    planProcessor.process(queryDetail)
-    var entities = atlasClient.createdEntities
-
-    // no entities should have been received from a creating a temporary view
-    assert(entities.isEmpty)
-
-    // we don't want to check above queries, so reset the entities in listener
-    testHelperQueryListener.clear()
-
-    sparkSession.sql(s"SELECT * FROM $destinationViewName3").write.saveAsTable(destinationTableName)
-
-    queryDetail = testHelperQueryListener.queryDetails.last
-    planProcessor.process(queryDetail)
-    entities = atlasClient.createdEntities
-
-    // we're expecting two table entities:
-    // one from the source table and another from the sink table, the temporary view is ignored
-    assert(!entities.isEmpty)
-    val tableEntities = listAtlasEntitiesAsType(entities, metadata.TABLE_TYPE_STRING)
-    assert(tableEntities.size === 2)
-
-    val inputEntity = getOneEntityOnAttribute(tableEntities, "name", sourceTblName)
-    val outputEntity = getOneEntityOnAttribute(tableEntities, "name", destinationTableName)
-    assertTableEntity(inputEntity, sourceTblName)
-    assertTableEntity(outputEntity, destinationTableName)
-
-    // check for 'spark_process'
-    val processEntity = getOnlyOneEntity(entities, metadata.PROCESS_TYPE_STRING)
-    val inputs = getSeqAtlasEntityAttribute(processEntity, "inputs")
-    val outputs = getSeqAtlasEntityAttribute(processEntity, "outputs")
-    assert(inputs.size === 1)
-    assert(outputs.size === 1)
-
-    // input/output in 'spark_process' should be same as outer entities
-    val input = getOnlyOneEntity(inputs, metadata.TABLE_TYPE_STRING)
-    val output = getOnlyOneEntity(outputs, metadata.TABLE_TYPE_STRING)
-    assert(input === inputEntity)
-    assert(output === outputEntity)
-  }
-
-  private def assertTableEntity(entity: AtlasEntity, tableName: String): Unit = {
-    val tableQualifiedName = getStringAttribute(entity, "qualifiedName")
-    assert(tableQualifiedName.contains(s"$tableName"))
+    outputEntity.entity.getAttribute("name") should be (destinationViewName2)
   }
 }

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
@@ -17,24 +17,23 @@
 
 package com.hortonworks.spark.atlas.sql
 
-import java.util
-
-import scala.collection.JavaConverters._
 import scala.util.Random
-
 import org.apache.atlas.AtlasClient
-import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
 import org.apache.spark.sql.execution.UnionExec
 import org.apache.spark.sql.hive.execution.InsertIntoHiveTable
-import org.scalatest.{Matchers, FunSuite}
-
-import com.hortonworks.spark.atlas.types.{metadata, external}
+import org.scalatest.{FunSuite, Matchers}
+import com.hortonworks.spark.atlas.types.{external, metadata}
 import com.hortonworks.spark.atlas.WithHiveSupport
+import com.hortonworks.spark.atlas.sql.testhelper.ProcessEntityValidator
 
 
-class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSupport {
+class InsertIntoHarvesterSuite
+  extends FunSuite
+  with Matchers
+  with WithHiveSupport
+  with ProcessEntityValidator {
 
   private val dataBase = "sac"
   private val sourceHiveTblName = "source_h_" + Random.nextInt(100000)
@@ -97,26 +96,21 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
     val cmd = node.cmd.asInstanceOf[InsertIntoHiveTable]
 
     val entities = CommandsHarvester.InsertIntoHiveTableHarvester.harvest(cmd, qd)
-    val pEntity = entities.head
-
-    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
-    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
-    inputs.size() should be (1)
-
-    val inputTbl = inputs.asScala.head
-    inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
-    inputTbl.getAttribute("name") should be (sourceHiveTblName)
-    inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
-      s"$dataBase.$sourceHiveTblName@primary")
-
-    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
-    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
-    outputs.size() should be (1)
-    val outputTbl = outputs.asScala.head
-    outputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
-    outputTbl.getAttribute("name") should be (destinationHiveTblName)
-    outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
-      s"$dataBase.$destinationHiveTblName@primary")
+    validateProcessEntity(entities.head, _ => {}, inputs => {
+      inputs.size should be (1)
+      val inputTbl = inputs.head.entity
+      inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+      inputTbl.getAttribute("name") should be (sourceHiveTblName)
+      inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
+        s"$dataBase.$sourceHiveTblName@primary")
+    }, outputs => {
+      outputs.size should be (1)
+      val outputTbl = outputs.head.entity
+      outputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+      outputTbl.getAttribute("name") should be (destinationHiveTblName)
+      outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
+        s"$dataBase.$destinationHiveTblName@primary")
+    })
   }
 
   test("INSERT INTO HIVE TABLE FROM HIVE TABLE (Cyclic)") {
@@ -130,20 +124,16 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
     val cmd = node.cmd.asInstanceOf[InsertIntoHiveTable]
 
     val entities = CommandsHarvester.InsertIntoHiveTableHarvester.harvest(cmd, qd)
-    val pEntity = entities.head
-
-    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
-    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
-    inputs.size() should be (1)
-
-    val inputTbl = inputs.asScala.head
-    inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
-    inputTbl.getAttribute("name") should be (destinationHiveTblName)
-    inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
-      s"$dataBase.$destinationHiveTblName@primary")
-
-    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
-    assert(pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]].isEmpty)
+    validateProcessEntity(entities.head, _ => {}, inputs => {
+      inputs.size should be (1)
+      val inputTbl = inputs.head.entity
+      inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+      inputTbl.getAttribute("name") should be (destinationHiveTblName)
+      inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
+        s"$dataBase.$destinationHiveTblName@primary")
+    }, outputs => {
+      assert(outputs.isEmpty)
+    })
   }
 
   test("INSERT INTO HIVE TABLE FROM SPARK TABLE") {
@@ -157,26 +147,21 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
     val cmd = node.cmd.asInstanceOf[InsertIntoHiveTable]
 
     val entities = CommandsHarvester.InsertIntoHiveTableHarvester.harvest(cmd, qd)
-    val pEntity = entities.head
-
-    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
-    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
-    inputs.size() should be (1)
-
-    val inputTbl = inputs.asScala.head
-    inputTbl.getTypeName should be (metadata.TABLE_TYPE_STRING)
-    inputTbl.getAttribute("name") should be (sourceSparkTblName)
-    inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
-      s"$dataBase.$sourceSparkTblName")
-
-    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
-    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
-    outputs.size() should be (1)
-    val outputTbl = outputs.asScala.head
-    outputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
-    outputTbl.getAttribute("name") should be (destinationHiveTblName)
-    outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
-      s"$dataBase.$destinationHiveTblName@primary")
+    validateProcessEntity(entities.head, _ => {}, inputs => {
+      inputs.size should be (1)
+      val inputTbl = inputs.head.entity
+      inputTbl.getTypeName should be (metadata.TABLE_TYPE_STRING)
+      inputTbl.getAttribute("name") should be (sourceSparkTblName)
+      inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should
+        endWith (s"$dataBase.$sourceSparkTblName")
+    }, outputs => {
+      outputs.size should be (1)
+      val outputTbl = outputs.head.entity
+      outputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+      outputTbl.getAttribute("name") should be (destinationHiveTblName)
+      outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
+        s"$dataBase.$destinationHiveTblName@primary")
+    })
   }
 
   test("INSERT INTO SPARK TABLE FROM HIVE TABLE") {
@@ -190,26 +175,21 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
     val cmd = node.cmd.asInstanceOf[InsertIntoHadoopFsRelationCommand]
 
     val entities = CommandsHarvester.InsertIntoHadoopFsRelationHarvester.harvest(cmd, qd)
-    val pEntity = entities.head
-
-    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
-    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
-    inputs.size() should be (1)
-
-    val inputTbl = inputs.asScala.head
-    inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
-    inputTbl.getAttribute("name") should be (sourceHiveTblName)
-    inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
-      s"$dataBase.$sourceHiveTblName@primary")
-
-    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
-    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
-    outputs.size() should be (1)
-    val outputTbl = outputs.asScala.head
-    outputTbl.getTypeName should be (metadata.TABLE_TYPE_STRING)
-    outputTbl.getAttribute("name") should be (destinationSparkTblName)
-    outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
-      s"$dataBase.$destinationSparkTblName")
+    validateProcessEntity(entities.head, _ => {}, inputs => {
+      inputs.size should be (1)
+      val inputTbl = inputs.head.entity
+      inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+      inputTbl.getAttribute("name") should be (sourceHiveTblName)
+      inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
+        s"$dataBase.$sourceHiveTblName@primary")
+    }, outputs => {
+      outputs.size should be (1)
+      val outputTbl = outputs.head.entity
+      outputTbl.getTypeName should be (metadata.TABLE_TYPE_STRING)
+      outputTbl.getAttribute("name") should be (destinationSparkTblName)
+      outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
+        s"$dataBase.$destinationSparkTblName")
+    })
   }
 
   test("INSERT INTO SPARK TABLE FROM SPARK TABLE") {
@@ -223,26 +203,21 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
     val cmd = node.cmd.asInstanceOf[InsertIntoHadoopFsRelationCommand]
 
     val entities = CommandsHarvester.InsertIntoHadoopFsRelationHarvester.harvest(cmd, qd)
-    val pEntity = entities.head
-
-    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
-    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
-    inputs.size() should be (1)
-
-    val inputTbl = inputs.asScala.head
-    inputTbl.getTypeName should be (metadata.TABLE_TYPE_STRING)
-    inputTbl.getAttribute("name") should be (sourceSparkTblName)
-    inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
-      s"$dataBase.$sourceSparkTblName")
-
-    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
-    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
-    outputs.size() should be (1)
-    val outputTbl = outputs.asScala.head
-    outputTbl.getTypeName should be (metadata.TABLE_TYPE_STRING)
-    outputTbl.getAttribute("name") should be (destinationSparkTblName)
-    outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
-      s"$dataBase.$destinationSparkTblName")
+    validateProcessEntity(entities.head, _ => {}, inputs => {
+      inputs.size should be (1)
+      val inputTbl = inputs.head.entity
+      inputTbl.getTypeName should be (metadata.TABLE_TYPE_STRING)
+      inputTbl.getAttribute("name") should be (sourceSparkTblName)
+      inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
+        s"$dataBase.$sourceSparkTblName")
+    }, outputs => {
+      outputs.size should be (1)
+      val outputTbl = outputs.head.entity
+      outputTbl.getTypeName should be (metadata.TABLE_TYPE_STRING)
+      outputTbl.getAttribute("name") should be (destinationSparkTblName)
+      outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
+        s"$dataBase.$destinationSparkTblName")
+    })
   }
 
   test("INSERT INTO SPARK TABLE FROM SPARK TABLE (Cyclic)") {
@@ -256,20 +231,16 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
     val cmd = node.cmd.asInstanceOf[InsertIntoHadoopFsRelationCommand]
 
     val entities = CommandsHarvester.InsertIntoHadoopFsRelationHarvester.harvest(cmd, qd)
-    val pEntity = entities.head
-
-    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
-    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
-    inputs.size() should be (1)
-
-    val inputTbl = inputs.asScala.head
-    inputTbl.getTypeName should be (metadata.TABLE_TYPE_STRING)
-    inputTbl.getAttribute("name") should be (destinationSparkTblName)
-    inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
-      s"$dataBase.$destinationSparkTblName")
-
-    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
-    assert(pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]].isEmpty)
+    validateProcessEntity(entities.head, _ => {}, inputs => {
+      inputs.size should be (1)
+      val inputTbl = inputs.head.entity
+      inputTbl.getTypeName should be (metadata.TABLE_TYPE_STRING)
+      inputTbl.getAttribute("name") should be (destinationSparkTblName)
+      inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should endWith (
+        s"$dataBase.$destinationSparkTblName")
+    }, outputs => {
+      assert(outputs.isEmpty)
+    })
   }
 
   test("INSERT INTO TABLE FROM MULTIPLE TABLES") {
@@ -284,26 +255,22 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
     val cmd = node.cmd.asInstanceOf[InsertIntoHiveTable]
 
     val entities = CommandsHarvester.InsertIntoHiveTableHarvester.harvest(cmd, qd)
-    val pEntity = entities.head
-
-    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
-    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
-    inputs.size() should be (3)
-
-    val inputTbl = inputs.asScala.head
-    inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
-    inputTbl.getAttribute("name").toString should startWith ("input")
-    inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should startWith (
-      s"$dataBase.input")
-
-    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
-    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
-    outputs.size() should be (1)
-    val outputTbl = outputs.asScala.head
-    outputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
-    outputTbl.getAttribute("name") should be (bigTable)
-    outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
-      s"$dataBase.$bigTable@primary")
+    validateProcessEntity(entities.head, _ => {}, inputs => {
+      inputs.size should be (3)
+      inputs.map(_.entity).foreach { inputTbl =>
+        inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+        inputTbl.getAttribute("name").toString should startWith ("input")
+        inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should startWith (
+          s"$dataBase.input")
+      }
+    }, outputs => {
+      outputs.size should be (1)
+      val outputTbl = outputs.head.entity
+      outputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+      outputTbl.getAttribute("name") should be (bigTable)
+      outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
+        s"$dataBase.$bigTable@primary")
+    })
   }
 
   test("INSERT INTO MULTIPLE TABLES FROM TABLE") {
@@ -322,26 +289,21 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
       val cmd = node.cmd.asInstanceOf[InsertIntoHiveTable]
 
       val entities = CommandsHarvester.InsertIntoHiveTableHarvester.harvest(cmd, qd)
-      val pEntity = entities.head
-
-      assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
-      val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
-      inputs.size() should be (1)
-
-      val inputTbl = inputs.asScala.head
-      inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
-      inputTbl.getAttribute("name") should be (bigTable)
-      inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
-        s"$dataBase.$bigTable@primary")
-
-      assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
-      val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
-      outputs.size() should be (1)
-      val outputTbl = outputs.asScala.head
-      outputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
-      outputTbl.getAttribute("name").toString should startWith ("output")
-      outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should startWith (
-        s"$dataBase.output")
+      validateProcessEntity(entities.head, _ => {}, inputs => {
+        inputs.size should be (1)
+        val inputTbl = inputs.head.entity
+        inputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+        inputTbl.getAttribute("name") should be (bigTable)
+        inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
+          s"$dataBase.$bigTable@primary")
+      }, outputs => {
+        outputs.size should be (1)
+        val outputTbl = outputs.head.entity
+        outputTbl.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
+        outputTbl.getAttribute("name").toString should startWith ("output")
+        outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should startWith (
+          s"$dataBase.output")
+      })
     })
   }
 
@@ -363,26 +325,22 @@ class InsertIntoHarvesterSuite extends FunSuite with Matchers with WithHiveSuppo
       val cmd = node.cmd.asInstanceOf[InsertIntoHiveTable]
 
       val entities = CommandsHarvester.InsertIntoHiveTableHarvester.harvest(cmd, qd)
-      val pEntity = entities.head
-
-      assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
-      val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasEntity]]
-      inputs.size() should be(3)
-
-      val inputTbl = inputs.asScala.head
-      inputTbl.getTypeName should be(external.HIVE_TABLE_TYPE_STRING)
-      inputTbl.getAttribute("name").toString should startWith("input")
-      inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should startWith(
-        s"$dataBase.input")
-
-      assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
-      val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasEntity]]
-      outputs.size() should be(1)
-      val outputTbl = outputs.asScala.head
-      outputTbl.getTypeName should be(external.HIVE_TABLE_TYPE_STRING)
-      outputTbl.getAttribute("name").toString should startWith("output")
-      outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should startWith(
-        s"$dataBase.output")
+      validateProcessEntity(entities.head, _ => {}, inputs => {
+        inputs.size should be (3)
+        inputs.map(_.entity).foreach { inputTbl =>
+          inputTbl.getTypeName should be(external.HIVE_TABLE_TYPE_STRING)
+          inputTbl.getAttribute("name").toString should startWith("input")
+          inputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should
+            startWith(s"$dataBase.input")
+        }
+      }, outputs => {
+        outputs.size should be (1)
+        val outputTbl = outputs.head.entity
+        outputTbl.getTypeName should be(external.HIVE_TABLE_TYPE_STRING)
+        outputTbl.getAttribute("name").toString should startWith("output")
+        outputTbl.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME).toString should startWith(
+          s"$dataBase.output")
+      })
     })
   }
 }

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForViewSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForViewSuite.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql
+
+import scala.util.Random
+import org.scalatest.{FunSuite, Matchers}
+import org.apache.atlas.model.instance.AtlasEntity
+import com.hortonworks.spark.atlas.AtlasEntityReadHelper._
+import com.hortonworks.spark.atlas.{AtlasClientConf, AtlasUtils, WithHiveSupport}
+import com.hortonworks.spark.atlas.sql.testhelper.{AtlasQueryExecutionListener, CreateEntitiesTrackingAtlasClient, DirectProcessSparkExecutionPlanProcessor, ProcessEntityValidator}
+import com.hortonworks.spark.atlas.types.metadata
+
+class SparkExecutionPlanProcessorForViewSuite
+  extends FunSuite
+  with Matchers
+  with WithHiveSupport
+  with ProcessEntityValidator {
+  private val sourceTblName = "source_" + Random.nextInt(100000)
+  private val destinationViewName = "destination_" + Random.nextInt(100000)
+  private val destinationTableName = "destination_" + Random.nextInt(100000)
+
+  private val testHelperQueryListener = new AtlasQueryExecutionListener()
+
+  var atlasClient: CreateEntitiesTrackingAtlasClient = _
+  val atlasClientConf: AtlasClientConf = new AtlasClientConf()
+    .set(AtlasClientConf.CHECK_MODEL_IN_START.key, "false")
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+
+    sparkSession.sql(s"CREATE TABLE $sourceTblName (name string)")
+    sparkSession.sql(s"INSERT INTO TABLE $sourceTblName VALUES ('lucy'), ('tom')")
+
+    // setup Atlas client
+    testHelperQueryListener.clear()
+    atlasClient = new CreateEntitiesTrackingAtlasClient()
+    sparkSession.listenerManager.register(testHelperQueryListener)
+  }
+
+  test("CREATE TEMPORARY VIEW FROM TABLE, SAVE TEMP VIEW TO TABLE") {
+    val planProcessor = new DirectProcessSparkExecutionPlanProcessor(atlasClient, atlasClientConf)
+    sparkSession.sql(s"SELECT * FROM $sourceTblName").createOrReplaceTempView(destinationViewName)
+
+    var queryDetail = testHelperQueryListener.queryDetails.last
+    planProcessor.process(queryDetail)
+    var entities = atlasClient.createdEntities
+
+    // no entities should have been received from a creating a temporary view
+    assert(entities.isEmpty)
+
+    // we don't want to check above queries, so reset the entities in listener
+    testHelperQueryListener.clear()
+
+    sparkSession.sql(s"SELECT * FROM $destinationViewName").write.saveAsTable(destinationTableName)
+
+    queryDetail = testHelperQueryListener.queryDetails.last
+    planProcessor.process(queryDetail)
+    entities = atlasClient.createdEntities
+
+    // we're expecting two table entities:
+    // one from the source table and another from the sink table, the temporary view is ignored
+    assert(entities.nonEmpty)
+    val tableEntities = listAtlasEntitiesAsType(entities, metadata.TABLE_TYPE_STRING)
+    assert(tableEntities.size === 2)
+
+    val inputEntity = getOnlyOneEntityOnAttribute(tableEntities, "name", sourceTblName)
+    val outputEntity = getOnlyOneEntityOnAttribute(tableEntities, "name", destinationTableName)
+    assertTableEntity(inputEntity, sourceTblName)
+    assertTableEntity(outputEntity, destinationTableName)
+
+    // check for 'spark_process'
+    validateProcessEntityWithAtlasEntities(entities, _ => {}, Seq(inputEntity), Seq(outputEntity))
+  }
+
+  private def assertTableEntity(entity: AtlasEntity, tableName: String): Unit = {
+    val tableQualifiedName = getStringAttribute(entity, "qualifiedName")
+    assert(tableQualifiedName.contains(s"$tableName"))
+  }
+}

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/FsEntityValidator.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/FsEntityValidator.scala
@@ -20,7 +20,7 @@ package com.hortonworks.spark.atlas.sql.testhelper
 import java.io.File
 import java.util.Locale
 
-import com.hortonworks.spark.atlas.sql.testhelper.AtlasEntityReadHelper.{getStringAttribute, listAtlasEntitiesAsType}
+import com.hortonworks.spark.atlas.AtlasEntityReadHelper.{getStringAttribute, listAtlasEntitiesAsType}
 import com.hortonworks.spark.atlas.types.external
 import org.apache.atlas.model.instance.AtlasEntity
 import org.scalatest.FunSuite

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/KafkaTopicEntityValidator.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/KafkaTopicEntityValidator.scala
@@ -20,7 +20,7 @@ package com.hortonworks.spark.atlas.sql.testhelper
 import com.hortonworks.spark.atlas.TestUtils
 import com.hortonworks.spark.atlas.sql.KafkaTopicInformation
 import org.scalatest.FunSuite
-import com.hortonworks.spark.atlas.sql.testhelper.AtlasEntityReadHelper.{getStringAttribute, listAtlasEntitiesAsType}
+import com.hortonworks.spark.atlas.AtlasEntityReadHelper.{getStringAttribute, listAtlasEntitiesAsType}
 import com.hortonworks.spark.atlas.types.external.KAFKA_TOPIC_STRING
 import org.apache.atlas.model.instance.AtlasEntity
 

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/ProcessEntityValidator.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/ProcessEntityValidator.scala
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas.sql.testhelper
+
+import java.util
+
+import com.hortonworks.spark.atlas.AtlasEntityReadHelper.getOnlyOneEntity
+import com.hortonworks.spark.atlas.types.metadata
+
+import scala.collection.JavaConverters._
+import com.hortonworks.spark.atlas.{AtlasEntityWithDependencies, AtlasUtils, TestUtils}
+import org.apache.atlas.model.instance.{AtlasEntity, AtlasObjectId}
+import org.scalatest.FunSuite
+
+trait ProcessEntityValidator extends FunSuite {
+  def validateProcessEntity(
+      process: AtlasEntityWithDependencies,
+      validateFnForProcess: AtlasEntity => Unit,
+      validateFnForInputs: Seq[AtlasEntityWithDependencies] => Unit,
+      validateFnForOutputs: Seq[AtlasEntityWithDependencies] => Unit): Unit = {
+    val pEntity = process.entity
+    validateFnForProcess(pEntity)
+
+    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
+    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
+    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasObjectId]]
+    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasObjectId]]
+
+    val pDeps = process.dependencies
+    val inputEntities = TestUtils.findEntities(pDeps, inputs.asScala.toSeq)
+    val outputEntities = TestUtils.findEntities(pDeps, outputs.asScala.toSeq)
+
+    assert(inputs.size() === inputEntities.size)
+    assert(outputs.size() === outputEntities.size)
+
+    validateFnForInputs(inputEntities)
+    validateFnForOutputs(outputEntities)
+  }
+
+  def validateProcessEntityWithAtlasEntities(
+      entities: Seq[AtlasEntity],
+      validateFnForProcess: AtlasEntity => Unit,
+      expectedInputEntities: Seq[AtlasEntity],
+      expectedOutputEntities: Seq[AtlasEntity]): Unit = {
+    val pEntity = getOnlyOneEntity(entities, metadata.PROCESS_TYPE_STRING)
+    validateFnForProcess(pEntity)
+
+    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
+    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
+    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasObjectId]]
+    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasObjectId]]
+
+    val expectedInputObjectIds = expectedInputEntities.map { entity =>
+      AtlasUtils.entityToReference(entity, useGuid = false)
+    }.toSet
+    val expectedOutputObjectIds = expectedOutputEntities.map { entity =>
+      AtlasUtils.entityToReference(entity, useGuid = false)
+    }.toSet
+
+    assert(inputs.asScala.toSet === expectedInputObjectIds)
+    assert(outputs.asScala.toSet === expectedOutputObjectIds)
+  }
+
+  def validateProcessEntityWithAtlasEntitiesForStreamingQuery(
+      entities: Seq[AtlasEntity],
+      validateFnForProcess: AtlasEntity => Unit,
+      expectedInputEntities: Seq[AtlasEntity],
+      expectedOutputEntities: Seq[AtlasEntity]): Unit = {
+    val pEntity = getOnlyOneEntity(entities, metadata.PROCESS_TYPE_STRING)
+    validateFnForProcess(pEntity)
+
+    assert(pEntity.getAttribute("inputs").isInstanceOf[util.Collection[_]])
+    assert(pEntity.getAttribute("outputs").isInstanceOf[util.Collection[_]])
+    val inputs = pEntity.getAttribute("inputs").asInstanceOf[util.Collection[AtlasObjectId]]
+    val outputs = pEntity.getAttribute("outputs").asInstanceOf[util.Collection[AtlasObjectId]]
+
+    val expectedInputObjectIds = expectedInputEntities.map { entity =>
+      AtlasUtils.entityToReference(entity, useGuid = false)
+    }.toSet
+    val expectedOutputObjectIds = expectedOutputEntities.map { entity =>
+      AtlasUtils.entityToReference(entity, useGuid = false)
+    }.toSet
+
+    assert(inputs.asScala.toSet === expectedInputObjectIds)
+    assert(outputs.asScala.toSet === expectedOutputObjectIds)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Please refer #231 to see rationalization of the patch.

This patch proposes breaking down single "create entities" request into dependency first multiple requests. To achieve this, this patch changes the basic approach of collecting entities to create, from flattened `Seq[AtlasEntity]` to `Seq[AtlasEntityWithDependencies]` which `AtlasEntityWithDependencies` has origin entity and dependencies - like a tree structure.

This patch also changes the type for reference attribute from `AtlasEntity` to `AtlasObjectId`, as Atlas cannot handle it across multiple requests. It worked when entities are included in same request.

Given this patch changes the basic approach across all codebase, this patch touches almost every parts of codebase - so instead of reviewing code changes in depth, any reviewer would be better to focus the test results among UTs, ITs, and manual tests.

## How was this patch tested?

Modified UTs, ITs with clean Atlas 1.1 instance, and manually tested with some queries.

For manual tests I'm attaching queries and screenshot of Atlas 1.1:

> table

>> query

```
spark.range(10).write.json("/tmp/sac/json-wip-entity-deps")
spark.sql("CREATE TABLE test_table_wip_entity_deps_a USING json location '/tmp/sac/json-wip-entity-deps'")
spark.sql("CREATE TABLE test_table_managed_wip_entity_deps_a SELECT * FROM test_table_wip_entity_deps_a")
```

>> screenshots

kind | screenshot
---- | -----------
spark_db | ![spark-db](https://user-images.githubusercontent.com/1317309/57427315-6811cc80-725e-11e9-94ff-c6bc512b2ffb.png)
spark_table_managed | ![spark-table-managed](https://user-images.githubusercontent.com/1317309/57427362-85469b00-725e-11e9-95f4-688853275b93.png)
spark_storagedesc_managed | ![spark-storagedesc-managed](https://user-images.githubusercontent.com/1317309/57427359-84ae0480-725e-11e9-957e-74bb65dcca72.png)
spark_table_external | ![spark-table-external](https://user-images.githubusercontent.com/1317309/57427360-84ae0480-725e-11e9-9f3a-12997c3ed322.png)
spark_storagedesc_external | ![spark-storagedesc-external](https://user-images.githubusercontent.com/1317309/57427358-84ae0480-725e-11e9-851a-90bf7fcf8a06.png)

> batch

>> query

```
val sourceTopics = Seq("sparksource1batch", "sparksource2batch")
val sourceTopics2 = Seq("sparksource2batch", "sparksource3batch")

val customClusterName = "custom_cluster"

val df = spark.read.format("kafka")
  .option("kafka.bootstrap.servers","localhost:9027")
  .option("subscribe", sourceTopics.mkString(","))
  .option("kafka.atlas.cluster.name", customClusterName)
  .option("startingOffsets", "earliest")
  .load()

val assignForDf2 = """{"sparksource2batch": [0, 1, 2, 3, 4], "sparksource3batch": [0, 1, 2, 3, 4]}"""

val df2 = spark.read.format("kafka")
  .option("kafka.bootstrap.servers", "localhost:9027")
  .option("assign", assignForDf2)
  .option("startingOffsets", "earliest")
  .load()

df.union(df2).write.mode("append").saveAsTable("wip_entity_deps")
```

>> screenshots

kind | screenshot
---- | -----------
spark_process | ![spark-process](https://user-images.githubusercontent.com/1317309/57427434-d48ccb80-725e-11e9-8d8e-7f5065029784.png)
input 1 | ![source-kafka-topic-1](https://user-images.githubusercontent.com/1317309/57427429-d3f43500-725e-11e9-8859-7ab0e4f7c132.png)
input 2 | ![source-kafka-topic-2](https://user-images.githubusercontent.com/1317309/57427431-d3f43500-725e-11e9-987d-88e733be1687.png)
input 3 | ![source-kafka-topic-2-another-cluster](https://user-images.githubusercontent.com/1317309/57427432-d48ccb80-725e-11e9-8ffa-f91aa0a43a09.png)
input 4 | ![source-kafka-topic-3](https://user-images.githubusercontent.com/1317309/57427433-d48ccb80-725e-11e9-9360-e5b0b3231d73.png)
output_spark_table | ![output-spark-table](https://user-images.githubusercontent.com/1317309/57427428-d3f43500-725e-11e9-952c-2008d0b81b30.png)
output_spark_storagedesc | ![output-spark-storagedesc](https://user-images.githubusercontent.com/1317309/57427426-d3f43500-725e-11e9-9548-545926cc1480.png)

> streaming

>> query

```
val bootstrapServers = "localhost:9027"
val checkpointLocation = "/tmp/mykafka3"
val sourceTopics = Seq("sparksource1streaming", "sparksource2streaming").mkString(",")
val sourceTopics2 = Seq("sparksource2streaming", "sparksource3streaming").mkString(",")
val targetTopic = "sparksinkstreaming"

val df = spark.readStream.format("kafka").option("kafka.bootstrap.servers", bootstrapServers).option("subscribe", sourceTopics).option("startingOffsets", "earliest").option("kafka.atlas.cluster.name", "source").load()

val df2 = spark.readStream.format("kafka").option("kafka.bootstrap.servers", bootstrapServers).option("subscribe", sourceTopics2).option("startingOffsets", "earliest").load()

df.union(df2).writeStream.format("kafka").option("kafka.bootstrap.servers", bootstrapServers).option("checkpointLocation", checkpointLocation).option("topic", targetTopic).option("kafka.atlas.cluster.name", "sink").start()
```

>> screenshots

kind | screenshot
---- | -----------
spark_process | ![spark-process](https://user-images.githubusercontent.com/1317309/57427490-1289ef80-725f-11e9-872c-da608663d5a2.png)
input 1 | ![source-kafka-topic-1](https://user-images.githubusercontent.com/1317309/57427485-1158c280-725f-11e9-9587-f8d34b5866e2.png)
input 2 | ![source-kafka-topic-2](https://user-images.githubusercontent.com/1317309/57427487-11f15900-725f-11e9-9a93-7b8935d3c8e6.png)
input 3 | ![source-kafka-topic-2-another-cluster](https://user-images.githubusercontent.com/1317309/57427488-11f15900-725f-11e9-8441-cc38980adc9a.png)
input 4 | ![source-kafka-topic-3](https://user-images.githubusercontent.com/1317309/57427489-11f15900-725f-11e9-8eed-11fdf5b67e2e.png)
output | ![output-kafka-topic](https://user-images.githubusercontent.com/1317309/57427484-1158c280-725f-11e9-90ef-20426ff04c8d.png)

This closes #231 