### PR TITLE
[SAC-233][CORE] Change the approach of linking entities from "reference" to "relationship"

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasEntityReadHelper.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasEntityReadHelper.scala
@@ -69,6 +69,12 @@ object AtlasEntityReadHelper {
     entity.getAttribute(attrName).asInstanceOf[AtlasObjectId]
   }
 
+  def getAtlasObjectIdRelationshipAttribute(
+      entity: AtlasEntity,
+      attrName: String): AtlasObjectId = {
+    entity.getRelationshipAttribute(attrName).asInstanceOf[AtlasObjectId]
+  }
+
   def getSeqAtlasEntityAttribute(
       entity: AtlasEntity,
       attrName: String): Seq[AtlasEntity] = {
@@ -79,5 +85,11 @@ object AtlasEntityReadHelper {
       entity: AtlasEntity,
       attrName: String): Seq[AtlasObjectId] = {
     entity.getAttribute(attrName).asInstanceOf[SeqWrapper[AtlasObjectId]].underlying
+  }
+
+  def getSeqAtlasObjectIdRelationshipAttribute(
+      entity: AtlasEntity,
+      attrName: String): Seq[AtlasObjectId] = {
+    entity.getRelationshipAttribute(attrName).asInstanceOf[SeqWrapper[AtlasObjectId]].underlying
   }
 }

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -30,8 +30,7 @@ import org.apache.commons.lang.RandomStringUtils
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogStorageFormat, CatalogTable}
-import org.apache.spark.sql.types.StructType
-import com.hortonworks.spark.atlas.{AtlasClient, AtlasEntityWithDependencies, AtlasUtils}
+import com.hortonworks.spark.atlas.{AtlasEntityWithDependencies, AtlasUtils}
 import com.hortonworks.spark.atlas.utils.{JdbcUtils, SparkUtils}
 
 
@@ -329,8 +328,8 @@ object external {
     tableDefinition.comment.foreach(tblEntity.setAttribute("comment", _))
     tableDefinition.viewText.foreach(tblEntity.setAttribute("viewOriginalText", _))
 
-    tblEntity.setAttribute("db", AtlasUtils.entityToReference(dbEntity.entity))
-    tblEntity.setAttribute("sd", AtlasUtils.entityToReference(sdEntity.entity))
+    tblEntity.setRelationshipAttribute("db", AtlasUtils.entityToReference(dbEntity.entity))
+    tblEntity.setRelationshipAttribute("sd", AtlasUtils.entityToReference(sdEntity.entity))
 
     new AtlasEntityWithDependencies(tblEntity, Seq(dbEntity, sdEntity))
   }
@@ -346,8 +345,10 @@ object external {
     val sdEntity = deps.filter(e => e.getTypeName.equals(HIVE_STORAGEDESC_TYPE_STRING)).head
 
     // override attribute with reference - Atlas should already have these entities
-    tableEntity.entity.setAttribute("db", AtlasUtils.entityToReference(dbEntity, useGuid = false))
-    tableEntity.entity.setAttribute("sd", AtlasUtils.entityToReference(sdEntity, useGuid = false))
+    tableEntity.entity.setRelationshipAttribute("db",
+      AtlasUtils.entityToReference(dbEntity, useGuid = false))
+    tableEntity.entity.setRelationshipAttribute("sd",
+      AtlasUtils.entityToReference(sdEntity, useGuid = false))
 
     // drop all the dependencies since they're not necessary
     AtlasEntityWithDependencies(tableEntity.entity)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -110,8 +110,10 @@ object internal extends Logging {
     tableDefinition.comment.foreach(tblEntity.setAttribute("comment", _))
     tblEntity.setAttribute("unsupportedFeatures", tableDefinition.unsupportedFeatures.asJava)
 
-    tblEntity.setAttribute("db", AtlasUtils.entityToReference(dbEntity.entity, useGuid = false))
-    tblEntity.setAttribute("sd", AtlasUtils.entityToReference(sdEntity.entity, useGuid = false))
+    tblEntity.setRelationshipAttribute("db",
+      AtlasUtils.entityToReference(dbEntity.entity, useGuid = false))
+    tblEntity.setRelationshipAttribute("sd",
+      AtlasUtils.entityToReference(sdEntity.entity, useGuid = false))
 
     new AtlasEntityWithDependencies(tblEntity, Seq(dbEntity, sdEntity))
   }
@@ -127,8 +129,10 @@ object internal extends Logging {
     val sdEntity = deps.filter(e => e.getTypeName.equals(metadata.STORAGEDESC_TYPE_STRING)).head
 
     // override attribute with reference - Atlas should already have these entities
-    tableEntity.entity.setAttribute("db", AtlasUtils.entityToReference(dbEntity, useGuid = false))
-    tableEntity.entity.setAttribute("sd", AtlasUtils.entityToReference(sdEntity, useGuid = false))
+    tableEntity.entity.setRelationshipAttribute("db",
+      AtlasUtils.entityToReference(dbEntity, useGuid = false))
+    tableEntity.entity.setRelationshipAttribute("sd",
+      AtlasUtils.entityToReference(sdEntity, useGuid = false))
 
     AtlasEntityWithDependencies(tableEntity.entity)
   }
@@ -181,7 +185,7 @@ object internal extends Logging {
 
     entity.setAttribute("qualifiedName", pipeline_uid)
     entity.setAttribute("name", pipeline_uid)
-    entity.setAttribute("directory",
+    entity.setRelationshipAttribute("directory",
       AtlasUtils.entityToReference(directory.entity, useGuid = false))
 
     new AtlasEntityWithDependencies(entity, Seq(directory))
@@ -195,7 +199,7 @@ object internal extends Logging {
     val uid = model_uid.replaceAll("pipeline", "model")
     entity.setAttribute("qualifiedName", uid)
     entity.setAttribute("name", uid)
-    entity.setAttribute("directory",
+    entity.setRelationshipAttribute("directory",
       AtlasUtils.entityToReference(directory.entity, useGuid = false))
 
     new AtlasEntityWithDependencies(entity, Seq(directory))

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
@@ -21,6 +21,9 @@ import com.google.common.collect.{ImmutableMap, ImmutableSet}
 import org.apache.atlas.AtlasConstants
 import org.apache.atlas.`type`.AtlasBuiltInTypes.{AtlasBooleanType, AtlasDateType, AtlasLongType, AtlasStringType}
 import org.apache.atlas.`type`.{AtlasArrayType, AtlasMapType, AtlasTypeUtil}
+import org.apache.atlas.model.typedef.AtlasRelationshipDef.{PropagateTags, RelationshipCategory}
+import org.apache.atlas.model.typedef.AtlasRelationshipEndDef
+import org.apache.atlas.model.typedef.AtlasStructDef.AtlasAttributeDef.Cardinality
 import org.apache.atlas.model.typedef.AtlasStructDef.AtlasConstraintDef
 
 object metadata {
@@ -28,12 +31,15 @@ object metadata {
   val DB_TYPE_STRING = "spark_db"
   val STORAGEDESC_TYPE_STRING = "spark_storagedesc"
   val TABLE_TYPE_STRING = "spark_table"
+  val TABLE_DB_RELATIONSHIP_TYPE_STRING = "spark_table_db_rel"
+  val TABLE_COLUMNS_RELATIONSHIP_TYPE_STRING = "spark_table_columns_rel"
+  val TABLE_STORAGEDESC_RELATIONSHIP_TYPE_STRING: String = "spark_table_storagedesc_rel"
   val PROCESS_TYPE_STRING = "spark_process"
   val ML_DIRECTORY_TYPE_STRING = "spark_ml_directory"
   val ML_PIPELINE_TYPE_STRING = "spark_ml_pipeline"
   val ML_MODEL_TYPE_STRING = "spark_ml_model"
-
-  import external._
+  val ML_PIPELINE_DIRECTORY_RELATIONSHIP_TYPE_STRING = "spark_ml_pipeline_directory_rel"
+  val ML_MODEL_DIRECTORY_RELATIONSHIP_TYPE_STRING = "spark_ml_model_directory_rel"
 
   // ========= DB type =========
   val DB_TYPE = AtlasTypeUtil.createClassTypeDef(
@@ -65,12 +71,7 @@ object metadata {
     AtlasTypeUtil.createOptionalAttrDef("serde", new AtlasStringType),
     AtlasTypeUtil.createRequiredAttrDef("compressed", new AtlasBooleanType),
     AtlasTypeUtil.createOptionalAttrDef(
-      "parameters", new AtlasMapType(new AtlasStringType, new AtlasStringType)),
-    AtlasTypeUtil.createOptionalAttrDefWithConstraint(
-      "table",
-      TABLE_TYPE_STRING,
-      AtlasConstraintDef.CONSTRAINT_TYPE_INVERSE_REF,
-      ImmutableMap.of(AtlasConstraintDef.CONSTRAINT_PARAM_ATTRIBUTE, "sd")))
+      "parameters", new AtlasMapType(new AtlasStringType, new AtlasStringType)))
 
   // ========= Table type =========
   val TABLE_TYPE = AtlasTypeUtil.createClassTypeDef(
@@ -80,10 +81,7 @@ object metadata {
     ImmutableSet.of("DataSet"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
       "qualifiedName", new AtlasStringType),
-    AtlasTypeUtil.createOptionalAttrDef("db", DB_TYPE_STRING),
     AtlasTypeUtil.createOptionalAttrDef("tableType", new AtlasStringType),
-    AtlasTypeUtil.createOptionalAttrDefWithConstraint(
-      "sd", STORAGEDESC_TYPE_STRING, AtlasConstraintDef.CONSTRAINT_TYPE_OWNED_REF, null),
     AtlasTypeUtil.createOptionalAttrDef("provider", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef(
       "partitionColumnNames", new AtlasArrayType(new AtlasStringType)),
@@ -98,6 +96,27 @@ object metadata {
     AtlasTypeUtil.createOptionalAttrDef(
       "unsupportedFeatures", new AtlasArrayType(new AtlasStringType)),
     AtlasTypeUtil.createOptionalAttrDef("viewOriginalText", new AtlasStringType))
+
+  // ========= Table-related relationship types =========
+  val TABLE_DB_RELATIONSHIP_TYPE = AtlasTypeUtil.createRelationshipTypeDef(
+    TABLE_DB_RELATIONSHIP_TYPE_STRING,
+    "",
+    METADATA_VERSION,
+    RelationshipCategory.ASSOCIATION,
+    PropagateTags.ONE_TO_TWO,
+    new AtlasRelationshipEndDef(TABLE_TYPE_STRING, "db", Cardinality.SINGLE),
+    new AtlasRelationshipEndDef(DB_TYPE_STRING, "tables", Cardinality.SET)
+  )
+
+  val TABLE_STORAGEDESC_RELATIONSHIP_TYPE = AtlasTypeUtil.createRelationshipTypeDef(
+    TABLE_STORAGEDESC_RELATIONSHIP_TYPE_STRING,
+    "",
+    METADATA_VERSION,
+    RelationshipCategory.ASSOCIATION,
+    PropagateTags.ONE_TO_TWO,
+    new AtlasRelationshipEndDef(TABLE_TYPE_STRING, "sd", Cardinality.SINGLE),
+    new AtlasRelationshipEndDef(STORAGEDESC_TYPE_STRING, "table", Cardinality.SINGLE)
+  )
 
   // ========= Process type =========
   val PROCESS_TYPE = AtlasTypeUtil.createClassTypeDef(
@@ -133,7 +152,6 @@ object metadata {
     ImmutableSet.of("DataSet"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
       "qualifiedName", new AtlasStringType),
-    AtlasTypeUtil.createRequiredAttrDef("directory", ML_DIRECTORY_TYPE_STRING),
     AtlasTypeUtil.createOptionalAttrDef("description", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("extra", new AtlasStringType))
 
@@ -145,8 +163,29 @@ object metadata {
     ImmutableSet.of("DataSet"),
     AtlasTypeUtil.createUniqueRequiredAttrDef(
       "qualifiedName", new AtlasStringType),
-    AtlasTypeUtil.createRequiredAttrDef("directory", ML_DIRECTORY_TYPE_STRING),
     AtlasTypeUtil.createOptionalAttrDef("description", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("extra", new AtlasStringType))
+
+  // ========= ML-related relationship types =========
+
+  val ML_PIPELINE_DIRECTORY_RELATIONSHIP_TYPE = AtlasTypeUtil.createRelationshipTypeDef(
+    ML_PIPELINE_DIRECTORY_RELATIONSHIP_TYPE_STRING,
+    "",
+    METADATA_VERSION,
+    RelationshipCategory.ASSOCIATION,
+    PropagateTags.ONE_TO_TWO,
+    new AtlasRelationshipEndDef(ML_PIPELINE_TYPE_STRING, "directory", Cardinality.SINGLE),
+    new AtlasRelationshipEndDef(ML_DIRECTORY_TYPE_STRING, "pipeline", Cardinality.SINGLE)
+  )
+
+  val ML_MODEL_DIRECTORY_RELATIONSHIP_TYPE = AtlasTypeUtil.createRelationshipTypeDef(
+    ML_MODEL_DIRECTORY_RELATIONSHIP_TYPE_STRING,
+    "",
+    METADATA_VERSION,
+    RelationshipCategory.ASSOCIATION,
+    PropagateTags.ONE_TO_TWO,
+    new AtlasRelationshipEndDef(ML_MODEL_TYPE_STRING, "directory", Cardinality.SINGLE),
+    new AtlasRelationshipEndDef(ML_DIRECTORY_TYPE_STRING, "model", Cardinality.SINGLE)
+  )
 
 }

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/BaseResourceIT.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/BaseResourceIT.scala
@@ -72,6 +72,8 @@ abstract class BaseResourceIT extends FunSuite with BeforeAndAfterAll with Befor
       typesDef.getClassificationDefs.get(0)
     } else if (!typesDef.getEntityDefs.isEmpty) {
       typesDef.getEntityDefs.get(0)
+    } else if (!typesDef.getRelationshipDefs.isEmpty) {
+      typesDef.getRelationshipDefs.get(0)
     } else {
       null
     }

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoRdbmsHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoRdbmsHarvesterSuite.scala
@@ -22,7 +22,7 @@ import java.sql.DriverManager
 
 import com.hortonworks.spark.atlas.{AtlasClientConf, AtlasUtils, WithHiveSupport}
 import com.hortonworks.spark.atlas.AtlasEntityReadHelper._
-import com.hortonworks.spark.atlas.sql.testhelper.{AtlasQueryExecutionListener, CreateEntitiesTrackingAtlasClient, DirectProcessSparkExecutionPlanProcessor}
+import com.hortonworks.spark.atlas.sql.testhelper.{AtlasQueryExecutionListener, CreateEntitiesTrackingAtlasClient, DirectProcessSparkExecutionPlanProcessor, ProcessEntityValidator}
 import com.hortonworks.spark.atlas.types.{external, metadata}
 import org.apache.atlas.model.instance.AtlasEntity
 
@@ -30,7 +30,8 @@ class InsertIntoRdbmsHarvesterSuite
   extends FunSuite
   with Matchers
   with BeforeAndAfter
-  with WithHiveSupport {
+  with WithHiveSupport
+  with ProcessEntityValidator {
 
   val sinkTableName = "sink_table"
   val sourceTableName = "source_table"
@@ -86,6 +87,7 @@ class InsertIntoRdbmsHarvesterSuite
     assertTableEntity(outputEntity, sinkTableName)
 
     // check for 'spark_process'
+
     val processEntity = getOnlyOneEntity(entities, metadata.PROCESS_TYPE_STRING)
 
     val inputs = getSeqAtlasObjectIdAttribute(processEntity, "inputs")

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForBatchQuerySuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForBatchQuerySuite.scala
@@ -382,7 +382,7 @@ class SparkExecutionPlanProcessorForBatchQuerySuite
     assert(getStringAttribute(databaseEntity, "qualifiedName") === databaseQualifiedName)
 
     // database entity in table entity should be same as outer database entity
-    val databaseEntityInTable = getAtlasObjectIdAttribute(tableEntity, "db")
+    val databaseEntityInTable = getAtlasObjectIdRelationshipAttribute(tableEntity, "db")
     assert(AtlasUtils.entityToReference(databaseEntity) === databaseEntityInTable)
 
     val databaseLocationString = getStringAttribute(databaseEntity, "location")
@@ -397,7 +397,7 @@ class SparkExecutionPlanProcessorForBatchQuerySuite
     val storageQualifiedName = tableQualifiedName + ".storageFormat"
     assert(getStringAttribute(sdEntity, "qualifiedName") === storageQualifiedName)
 
-    val storageEntityInTableAttribute = getAtlasObjectIdAttribute(tableEntity, "sd")
+    val storageEntityInTableAttribute = getAtlasObjectIdRelationshipAttribute(tableEntity, "sd")
     assert(AtlasUtils.entityToReference(sdEntity) === storageEntityInTableAttribute)
   }
 

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForHiveMetastoreTableSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForHiveMetastoreTableSuite.scala
@@ -110,7 +110,7 @@ class SparkExecutionPlanProcessorForHiveMetastoreTableSuite
     assert(getStringAttribute(databaseEntity, "qualifiedName") === databaseQualifiedName)
 
     // database entity in table entity should be same as outer database entity
-    val databaseEntityInTable = getAtlasObjectIdAttribute(tableEntity, "db")
+    val databaseEntityInTable = getAtlasObjectIdRelationshipAttribute(tableEntity, "db")
     assert(AtlasUtils.entityToReference(databaseEntity) === databaseEntityInTable)
 
     val databaseLocationString = getStringAttribute(databaseEntity, "location")
@@ -125,7 +125,7 @@ class SparkExecutionPlanProcessorForHiveMetastoreTableSuite
     val storageQualifiedName = tableQualifiedName + "_storage"
     assert(getStringAttribute(sdEntity, "qualifiedName") === storageQualifiedName)
 
-    val storageEntityInTableAttribute = getAtlasObjectIdAttribute(tableEntity, "sd")
+    val storageEntityInTableAttribute = getAtlasObjectIdRelationshipAttribute(tableEntity, "sd")
     assert(AtlasUtils.entityToReference(sdEntity) === storageEntityInTableAttribute)
   }
 }

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/AtlasExternalEntityUtilsSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/AtlasExternalEntityUtilsSuite.scala
@@ -88,9 +88,9 @@ class AtlasExternalEntityUtilsSuite extends FunSuite with Matchers with WithHive
 
     tableEntity.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
     tableEntity.getAttribute("name") should be ("tbl1")
-    tableEntity.getAttribute("db") should be (
+    tableEntity.getRelationshipAttribute("db") should be (
       AtlasUtils.entityToReference(dbEntity, useGuid = false))
-    tableEntity.getAttribute("sd") should be (
+    tableEntity.getRelationshipAttribute("sd") should be (
       AtlasUtils.entityToReference(sdEntity, useGuid = false))
     tableEntity.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
       "db1.tbl1@primary")
@@ -141,7 +141,6 @@ class AtlasExternalEntityUtilsSuite extends FunSuite with Matchers with WithHive
     pathEntity.entity.getAttribute("name") should be ("testfile")
     pathEntity.entity.getAttribute("qualifiedName") should be (
       "s3://testbucket/testpseudodir/testfile")
-
 
     val deps = pathEntity.dependencies
     val dirEntity = deps.find(_.entity.getTypeName == external.S3_PSEUDO_DIR_TYPE_STRING)

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/MLAtlasEntityUtilsSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/MLAtlasEntityUtilsSuite.scala
@@ -85,7 +85,7 @@ class MLAtlasEntityUtilsSuite extends FunSuite with Matchers with WithHiveSuppor
     pipelineEntity.entity.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
       pipeline.uid)
     pipelineEntity.entity.getAttribute("name") should be (pipeline.uid)
-    pipelineEntity.entity.getAttribute("directory") should be (
+    pipelineEntity.entity.getRelationshipAttribute("directory") should be (
       AtlasUtils.entityToReference(pipelineDirEntity.entity, useGuid = false))
     pipelineEntity.dependencies should be (Seq(pipelineDirEntity))
 
@@ -94,7 +94,7 @@ class MLAtlasEntityUtilsSuite extends FunSuite with Matchers with WithHiveSuppor
     modelEntity.entity.getTypeName should be (metadata.ML_MODEL_TYPE_STRING)
     modelEntity.entity.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (modelUid)
     modelEntity.entity.getAttribute("name") should be (modelUid)
-    modelEntity.entity.getAttribute("directory") should be (
+    modelEntity.entity.getRelationshipAttribute("directory") should be (
       AtlasUtils.entityToReference(modelDirEntity.entity, useGuid = false))
 
     modelEntity.dependencies should be (Seq(modelDirEntity))

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/SparkAtlasEntityUtilsSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/types/SparkAtlasEntityUtilsSuite.scala
@@ -104,10 +104,10 @@ class SparkAtlasEntityUtilsSuite extends FunSuite with Matchers with BeforeAndAf
     tableEntity.entity.getAttribute("owner") should be (SparkUtils.currUser())
     tableEntity.entity.getAttribute("ownerType") should be ("USER")
 
-    tableEntity.entity.getAttribute("db") should be (
+    tableEntity.entity.getRelationshipAttribute("db") should be (
       AtlasUtils.entityToReference(dbEntity, useGuid = false))
 
-    tableEntity.entity.getAttribute("sd") should be (
+    tableEntity.entity.getRelationshipAttribute("sd") should be (
       AtlasUtils.entityToReference(sdEntity, useGuid = false))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes change the way of linking related entities from "reference" to "relationship". This patch includes the change of models to apply relationship, as well as code change to link via relationship attribute instead of normal attribute.

Please note that this patch don't change the current approach for "process" and "aws s3" types, since these models define these attributes in both attributes and relationship attributes.

## How was this patch tested?

Modified UTs, ITs with fresh Atlas 1.1, manually tested with Spark 2.4 & Atlas 1.1 via below query:

> query

```
val sourceTopics = Seq("sparksource1batch-sac-233", "sparksource2batch-sac-233")
val sourceTopics2 = Seq("sparksource2batch-sac-233", "sparksource3batch-sac-233")

val customClusterName = "custom_cluster"

val df = spark.read.format("kafka")
  .option("kafka.bootstrap.servers","localhost:9027")
  .option("subscribe", sourceTopics.mkString(","))
  .option("kafka.atlas.cluster.name", customClusterName)
  .option("startingOffsets", "earliest")
  .load()

val assignForDf2 = """{"sparksource2batch-sac-233": [0, 1, 2, 3, 4], "sparksource3batch-sac-233": [0, 1, 2, 3, 4]}"""

val df2 = spark.read.format("kafka")
  .option("kafka.bootstrap.servers", "localhost:9027")
  .option("assign", assignForDf2)
  .option("startingOffsets", "earliest")
  .load()

df.union(df2).write.mode("append").saveAsTable("sac_233_a_1")
```

and run below query just after running above query:

```
val sourceTopics = Seq("sparksource1batch-sac-233", "sparksource2batch-sac-233")
val sourceTopics2 = Seq("sparksource2batch-sac-233", "sparksource3batch-sac-233")

val customClusterName = "custom_cluster"

val df = spark.read.format("kafka")
  .option("kafka.bootstrap.servers","localhost:9027")
  .option("subscribe", sourceTopics.mkString(","))
  .option("kafka.atlas.cluster.name", customClusterName)
  .option("startingOffsets", "earliest")
  .load()

val assignForDf2 = """{"sparksource2batch-sac-233": [0, 1, 2, 3, 4], "sparksource3batch-sac-233": [0, 1, 2, 3, 4]}"""

val df2 = spark.read.format("kafka")
  .option("kafka.bootstrap.servers", "localhost:9027")
  .option("assign", assignForDf2)
  .option("startingOffsets", "earliest")
  .load()

df.union(df2).write.mode("append").saveAsTable("sac_233_a_2")
```

> snapshots

 kind | snapshot
---- | ----------
spark-process | <img width="1038" alt="spark-process" src="https://user-images.githubusercontent.com/1317309/57449891-0d956200-7298-11e9-9455-ad0939274fd6.png">
spark-process-relationships | <img width="477" alt="spark-process-relationships" src="https://user-images.githubusercontent.com/1317309/57449892-0e2df880-7298-11e9-8e1f-ded8d20d4d2e.png">
spark-table-1 | <img width="573" alt="spark-table-1" src="https://user-images.githubusercontent.com/1317309/57449895-0ec68f00-7298-11e9-818e-7175c3a4c6b6.png">
spark-table-1-relationships | <img width="362" alt="spark-table-1-relationships-spark-db" src="https://user-images.githubusercontent.com/1317309/57449897-0ec68f00-7298-11e9-9c71-ab28aa737e9a.png"><br/><img width="372" alt="spark-table-1-relationships-spark-process" src="https://user-images.githubusercontent.com/1317309/57449898-0ec68f00-7298-11e9-852b-cb482ec62f56.png"><br/><img width="367" alt="spark-table-1-relationships-spark-storagedesc" src="https://user-images.githubusercontent.com/1317309/57449900-0ec68f00-7298-11e9-8aeb-da3d978ba79d.png">
spark-storagedesc-1 | <img width="623" alt="spark-storagedesc-1" src="https://user-images.githubusercontent.com/1317309/57449893-0e2df880-7298-11e9-8e39-a310828b3eec.png">
spark-storagedesc-1-relationships | <img width="620" alt="spark-storagedesc-1-relationships" src="https://user-images.githubusercontent.com/1317309/57449894-0e2df880-7298-11e9-8f1b-3995984fcc02.png">
spark-table-2 | <img width="560" alt="spark-table-2" src="https://user-images.githubusercontent.com/1317309/57449901-0f5f2580-7298-11e9-9a1d-a81975ce4685.png">
spark-table-2-relationships | <img width="310" alt="spark-table-2-relationships" src="https://user-images.githubusercontent.com/1317309/57449902-0f5f2580-7298-11e9-9fbd-e3518de16ae2.png">
spark-db | <img width="563" alt="spark-db" src="https://user-images.githubusercontent.com/1317309/57449889-0d956200-7298-11e9-83ca-5a154265b4ab.png">
spark-db-relationships | <img width="355" alt="spark-db-relationships" src="https://user-images.githubusercontent.com/1317309/57449890-0d956200-7298-11e9-9798-169f71a5dd4b.png">

In relationships of spark-process, there're two outputs being linked together - this is current limitation of SAC which spark-process takes application ID as qualified name.
Note that spark-db has two tables for relationships - this is a one of good points for changing the way of linking entities to relationships. That was not tracked in current way of linking.

This closes #233 