### PR TITLE
[MINOR][BUILD] Remove unnecessary running tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ notifications:
   email: false
 
 install:
-  - mvn -q clean checkstyle:check scalastyle:check package
+  - mvn -q clean checkstyle:check scalastyle:check package -DskipTests


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch removes unnecessary running tests in Travis CI. By default, Travis CI runs `mvn test -B` after executing commands in `install` section.

## How was this patch tested?

Verified PR build for Travis CI. See the difference of build time between recent PR build and previous builds.

<img width="916" alt="Screen Shot 2019-05-09 at 9 40 46 PM" src="https://user-images.githubusercontent.com/1317309/57454146-25261800-72a3-11e9-8368-0bbc14691c84.png">
