### PR TITLE
[SAC-240] [CORE] Add additional attributes to spark_table

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -310,6 +310,12 @@ object external {
     tblEntity.setAttribute("tableType", tableDefinition.tableType.name)
     tblEntity.setAttribute("createTime", new Date(tableDefinition.createTime))
     tblEntity.setAttribute("parameters", tableDefinition.properties.asJava)
+    tblEntity.setAttribute("schemaDesc", tableDefinition.schema.simpleString)
+    tblEntity.setAttribute("provider", tableDefinition.provider.getOrElse(""))
+    if (tableDefinition.tracksPartitionsInCatalog) {
+      tblEntity.setAttribute("partitionProvider", "Catalog")
+    }
+    tblEntity.setAttribute("partitionColumnNames", tableDefinition.partitionColumnNames.asJava)
     tableDefinition.comment.foreach(tblEntity.setAttribute("comment", _))
     tableDefinition.viewText.foreach(tblEntity.setAttribute("viewOriginalText", _))
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -99,7 +99,11 @@ object internal extends Logging {
       sparkTableUniqueAttribute(db, tableDefinition.identifier.table))
     tblEntity.setAttribute("name", tableDefinition.identifier.table)
     tblEntity.setAttribute("tableType", tableDefinition.tableType.name)
-    tableDefinition.provider.foreach(tblEntity.setAttribute("provider", _))
+    tblEntity.setAttribute("schemaDesc", tableDefinition.schema.simpleString)
+    tblEntity.setAttribute("provider", tableDefinition.provider.getOrElse(""))
+    if (tableDefinition.tracksPartitionsInCatalog) {
+      tblEntity.setAttribute("partitionProvider", "Catalog")
+    }
     tblEntity.setAttribute("partitionColumnNames", tableDefinition.partitionColumnNames.asJava)
     tableDefinition.bucketSpec.foreach(
       b => tblEntity.setAttribute("bucketSpec", b.toLinkedHashMap.asJava))

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
@@ -81,7 +81,9 @@ object metadata {
     AtlasTypeUtil.createUniqueRequiredAttrDef(
       "qualifiedName", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("tableType", new AtlasStringType),
+    AtlasTypeUtil.createOptionalAttrDef("schemaDesc", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("provider", new AtlasStringType),
+    AtlasTypeUtil.createOptionalAttrDef("partitionProvider", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef(
       "partitionColumnNames", new AtlasArrayType(new AtlasStringType)),
     AtlasTypeUtil.createOptionalAttrDef(

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateDataSourceTableAsSelectHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateDataSourceTableAsSelectHarvesterSuite.scala
@@ -76,5 +76,7 @@ class CreateDataSourceTableAsSelectHarvesterSuite
     assert(maybeEntity.isDefined, s"Output entity for table [$destTblName] was not found.")
     assert(maybeEntity.get.getAttribute("name") == destTblName)
     assert(maybeEntity.get.getAttribute("owner") == SparkUtils.currUser())
+    assert(maybeEntity.get.getAttribute("schemaDesc") == "struct<name:string,age:int>")
+    assert(maybeEntity.get.getAttribute("provider") == "parquet")
   }
 }

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateDataSourceTableAsSelectHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateDataSourceTableAsSelectHarvesterSuite.scala
@@ -18,9 +18,9 @@
 package com.hortonworks.spark.atlas.sql
 
 import scala.util.Random
-
 import com.hortonworks.spark.atlas.WithHiveSupport
 import com.hortonworks.spark.atlas.utils.SparkUtils
+import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
 import org.apache.spark.sql.execution.command.CreateDataSourceTableAsSelectCommand
@@ -40,7 +40,17 @@ class CreateDataSourceTableAsSelectHarvesterSuite
     sparkSession.sql(s"CREATE TABLE $sourceTblName (name string, age int)")
   }
 
-  test("saveAsTable should have output entity having table details") {
+  test("saveAsTable should have output entity having table details - parquet") {
+    testWithProvider("parquet")
+
+  }
+
+  test("saveAsTable should have output entity having table details - hive") {
+    val entity = testWithProvider("hive")
+    assert(entity.getAttribute("partitionProvider") == "Catalog")
+  }
+
+  def testWithProvider(provider: String): AtlasEntity = {
     val destTblName = "dest1_" + Random.nextInt(100000)
     val df = sparkSession.sql(s"SELECT * FROM $sourceTblName")
 
@@ -54,7 +64,7 @@ class CreateDataSourceTableAsSelectHarvesterSuite
       tableType = CatalogTableType.EXTERNAL,
       storage = storage,
       schema = new StructType,
-      provider = Some("parquet"),
+      provider = Some(provider),
       partitionColumnNames = Nil,
       bucketSpec = None)
     val cmd = CreateDataSourceTableAsSelectCommand(
@@ -77,6 +87,7 @@ class CreateDataSourceTableAsSelectHarvesterSuite
     assert(maybeEntity.get.getAttribute("name") == destTblName)
     assert(maybeEntity.get.getAttribute("owner") == SparkUtils.currUser())
     assert(maybeEntity.get.getAttribute("schemaDesc") == "struct<name:string,age:int>")
-    assert(maybeEntity.get.getAttribute("provider") == "parquet")
+    assert(maybeEntity.get.getAttribute("provider") == provider)
+    maybeEntity.get
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This patch proposes to add additional attributes to spark_table viz. schema, provider, partitionProvider, partitionColumnNames.

## How was this patch tested?

* Modified existing UT to validate generated Atlas entity attribute.
* Manually tested.

Queries:

spark.range(10).write.json("/tmp/sac/json-wip-entity-deps")

1. spark.sql("CREATE TABLE test_table_wip_entity_deps_a USING json location '/tmp/sac/json-wip-entity-deps'")

<img width="974" alt="Screen Shot 2019-05-14 at 11 47 06 AM" src="https://user-images.githubusercontent.com/6792890/57730762-07173980-764e-11e9-993a-07b94aeeef05.png">

2. spark.sql("CREATE TABLE test_table_managed_wip_entity_deps_a SELECT * FROM test_table_wip_entity_deps_a")

<img width="918" alt="Screen Shot 2019-05-14 at 11 47 42 AM" src="https://user-images.githubusercontent.com/6792890/57723814-4b024280-763e-11e9-8d75-c1edd0c648f2.png">
