### PR TITLE
[SAC-242][SQL] Hive provider table entity and corresponding entities should reside to Hive models

### DIFF
--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForHiveMetastoreTableSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForHiveMetastoreTableSuite.scala
@@ -21,7 +21,7 @@ import java.nio.file.Files
 
 import com.hortonworks.spark.atlas.{AtlasClientConf, AtlasUtils, WithHiveSupport}
 import com.hortonworks.spark.atlas.sql.testhelper.{AtlasQueryExecutionListener, CreateEntitiesTrackingAtlasClient, DirectProcessSparkExecutionPlanProcessor}
-import com.hortonworks.spark.atlas.types.metadata
+import com.hortonworks.spark.atlas.types.{external, metadata}
 import org.apache.atlas.model.instance.AtlasEntity
 import org.apache.spark.sql.kafka010.KafkaTestUtils
 import org.scalatest.{BeforeAndAfterEach, FunSuite, Matchers}
@@ -72,15 +72,15 @@ class SparkExecutionPlanProcessorForHiveMetastoreTableSuite
     planProcessor.process(queryDetail)
     val entities = atlasClient.createdEntities
 
-    val tableEntity: AtlasEntity = getOnlyOneEntity(entities, metadata.TABLE_TYPE_STRING)
+    val tableEntity: AtlasEntity = getOnlyOneEntity(entities, external.HIVE_TABLE_TYPE_STRING)
     assertTableEntity(tableEntity, outputTableName)
 
     // database
-    val databaseEntity: AtlasEntity = getOnlyOneEntity(entities, metadata.DB_TYPE_STRING)
+    val databaseEntity: AtlasEntity = getOnlyOneEntity(entities, external.HIVE_DB_TYPE_STRING)
     assertDatabaseEntity(databaseEntity, tableEntity, outputTableName)
 
     // storage description
-    val storageEntity = getOnlyOneEntity(entities, metadata.STORAGEDESC_TYPE_STRING)
+    val storageEntity = getOnlyOneEntity(entities, external.HIVE_STORAGEDESC_TYPE_STRING)
     assertStorageDefinitionEntity(storageEntity, tableEntity)
 
     val databaseLocationString = getStringAttribute(databaseEntity, "location")

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForViewSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForViewSuite.scala
@@ -23,7 +23,7 @@ import org.apache.atlas.model.instance.AtlasEntity
 import com.hortonworks.spark.atlas.AtlasEntityReadHelper._
 import com.hortonworks.spark.atlas.{AtlasClientConf, AtlasUtils, WithHiveSupport}
 import com.hortonworks.spark.atlas.sql.testhelper.{AtlasQueryExecutionListener, CreateEntitiesTrackingAtlasClient, DirectProcessSparkExecutionPlanProcessor, ProcessEntityValidator}
-import com.hortonworks.spark.atlas.types.metadata
+import com.hortonworks.spark.atlas.types.{external, metadata}
 
 class SparkExecutionPlanProcessorForViewSuite
   extends FunSuite
@@ -75,11 +75,14 @@ class SparkExecutionPlanProcessorForViewSuite
     // we're expecting two table entities:
     // one from the source table and another from the sink table, the temporary view is ignored
     assert(entities.nonEmpty)
-    val tableEntities = listAtlasEntitiesAsType(entities, metadata.TABLE_TYPE_STRING)
-    assert(tableEntities.size === 2)
+    val sparkTableEntities = listAtlasEntitiesAsType(entities, metadata.TABLE_TYPE_STRING)
+    assert(sparkTableEntities.size === 1)
 
-    val inputEntity = getOnlyOneEntityOnAttribute(tableEntities, "name", sourceTblName)
-    val outputEntity = getOnlyOneEntityOnAttribute(tableEntities, "name", destinationTableName)
+    val hiveTableEntities = listAtlasEntitiesAsType(entities, external.HIVE_TABLE_TYPE_STRING)
+    assert(hiveTableEntities.size === 1)
+
+    val inputEntity = getOnlyOneEntityOnAttribute(hiveTableEntities, "name", sourceTblName)
+    val outputEntity = getOnlyOneEntityOnAttribute(sparkTableEntities, "name", destinationTableName)
     assertTableEntity(inputEntity, sourceTblName)
     assertTableEntity(outputEntity, destinationTableName)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Please refer #242 to see rationalization of the issue.

This patch effectively rolls back the change what #84 was introduced. SAC will leverage Hive models for Hive provider table. It doesn't only apply to Hive table entity - it also applies to Hive DB and Hive storagedesc entities as well.

## How was this patch tested?

Modified UTs, existing ITs, manually tested with local Apache Spark 2.4 & Apache Atlas 1.1:

> Query

```
spark.range(10).write.json("/tmp/sac/json-sac-242")
spark.sql("CREATE TABLE test_table_sac_242_a USING json location '/tmp/sac/json-sac-242'")
spark.sql("CREATE TABLE test_table_managed_sac_242_a SELECT * FROM test_table_sac_242_a")
```

> Screenshot

kind | screenshot
-- | --
spark_process - relationship | <img width="772" alt="spark-process-relationship-inputs" src="https://user-images.githubusercontent.com/1317309/57686217-2628c200-7674-11e9-9810-f6e4736324bb.png"><br/><img width="764" alt="spark-process-relationship-outputs" src="https://user-images.githubusercontent.com/1317309/57686218-2628c200-7674-11e9-988f-24309ef81852.png">
spark_db | <img width="581" alt="spark-db" src="https://user-images.githubusercontent.com/1317309/57686215-25902b80-7674-11e9-84eb-faaeee790b80.png">
spark_db - relationship | <img width="453" alt="spark-db-relationship-table" src="https://user-images.githubusercontent.com/1317309/57686216-2628c200-7674-11e9-96f2-7e0fc9a9dc98.png">
spark_storagedesc | <img width="689" alt="spark-storagedesc" src="https://user-images.githubusercontent.com/1317309/57686219-26c15880-7674-11e9-951d-be83a1c680f3.png">
spark_storagedesc - relationship | <img width="687" alt="spark-storagedesc-relationship-table" src="https://user-images.githubusercontent.com/1317309/57686220-26c15880-7674-11e9-8751-a0ce1ef417ac.png">
spark_table | <img width="581" alt="spark-table" src="https://user-images.githubusercontent.com/1317309/57686221-26c15880-7674-11e9-8bd6-4b6b4590cc7a.png">
spark_table - relationship | <img width="418" alt="spark-table-relationship-db" src="https://user-images.githubusercontent.com/1317309/57686223-2759ef00-7674-11e9-84e2-28198c5cab92.png"><br/><img width="418" alt="spark-table-relationship-storagedesc" src="https://user-images.githubusercontent.com/1317309/57686225-2759ef00-7674-11e9-918d-8fb60fb3491b.png">
hive_db | <img width="581" alt="hive-db" src="https://user-images.githubusercontent.com/1317309/57686208-245efe80-7674-11e9-9664-aee457b459cf.png">
hive_db - relationship | <img width="379" alt="hive-db-relationship" src="https://user-images.githubusercontent.com/1317309/57686210-24f79500-7674-11e9-97e8-8e14c0d5f7c3.png">
hive_storagedesc | <img width="719" alt="hive-storagedesc" src="https://user-images.githubusercontent.com/1317309/57686212-24f79500-7674-11e9-918d-e1bbdc71f97e.png">
hive_storagedesc - relationship | FIXME: somehow it does show relationship information!
hive_table | <img width="552" alt="hive-table" src="https://user-images.githubusercontent.com/1317309/57686213-25902b80-7674-11e9-9986-659dbcb64fae.png">
hive_table - relationship | <img width="367" alt="hive-table-relationship" src="https://user-images.githubusercontent.com/1317309/57686214-25902b80-7674-11e9-8795-af7e68babd81.png">
fs_path | <img width="536" alt="fs-path" src="https://user-images.githubusercontent.com/1317309/57686206-245efe80-7674-11e9-8904-ad6bb004d7fa.png">
fs_path - relationship | <img width="466" alt="fs-path-relationship-process" src="https://user-images.githubusercontent.com/1317309/57686207-245efe80-7674-11e9-925c-8d64f0172b8a.png">

Note that before the patch both of two tables leverage Spark models. Please refer the PR description of https://github.com/hortonworks-spark/spark-atlas-connector/pull/232