### PR TITLE
[SAC-246][CORE] Use current db name in current Spark session when Spark table information doesn't provide db name

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -201,8 +201,8 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
   }
 
   def prepareEntity(tableIdentifier: TableIdentifier): AtlasEntityWithDependencies = {
-    val tableName = tableIdentifier.table
-    val dbName = tableIdentifier.database.getOrElse(SparkUtils.getCurrentDatabase)
+    val tableName = SparkUtils.getTableName(tableIdentifier)
+    val dbName = SparkUtils.getDatabaseName(tableIdentifier)
     val tableDef = SparkUtils.getExternalCatalog().getTable(dbName, tableName)
     tableToEntity(tableDef)
   }

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -202,7 +202,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
 
   def prepareEntity(tableIdentifier: TableIdentifier): AtlasEntityWithDependencies = {
     val tableName = tableIdentifier.table
-    val dbName = tableIdentifier.database.getOrElse("default")
+    val dbName = tableIdentifier.database.getOrElse(SparkUtils.getCurrentDatabase)
     val tableDef = SparkUtils.getExternalCatalog().getTable(dbName, tableName)
     tableToEntity(tableDef)
   }

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -292,8 +292,8 @@ object external {
       cluster: String,
       mockDbDefinition: Option[CatalogDatabase] = None): AtlasEntityWithDependencies = {
     val tableDefinition = SparkUtils.getCatalogTableIfExistent(tblDefinition)
-    val db = tableDefinition.identifier.database.getOrElse(SparkUtils.getCurrentDatabase)
-    val table = tableDefinition.identifier.table
+    val db = SparkUtils.getDatabaseName(tableDefinition)
+    val table = SparkUtils.getTableName(tableDefinition)
     val dbDefinition = mockDbDefinition.getOrElse(SparkUtils.getExternalCatalog().getDatabase(db))
 
     val dbEntity = hiveDbToEntity(dbDefinition, cluster, tableDefinition.owner)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -292,7 +292,7 @@ object external {
       cluster: String,
       mockDbDefinition: Option[CatalogDatabase] = None): AtlasEntityWithDependencies = {
     val tableDefinition = SparkUtils.getCatalogTableIfExistent(tblDefinition)
-    val db = tableDefinition.identifier.database.getOrElse("default")
+    val db = tableDefinition.identifier.database.getOrElse(SparkUtils.getCurrentDatabase)
     val table = tableDefinition.identifier.table
     val dbDefinition = mockDbDefinition.getOrElse(SparkUtils.getExternalCatalog().getDatabase(db))
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -85,7 +85,7 @@ object internal extends Logging {
       clusterName: String,
       mockDbDefinition: Option[CatalogDatabase] = None): AtlasEntityWithDependencies = {
     val tableDefinition = SparkUtils.getCatalogTableIfExistent(tblDefinition)
-    val db = tableDefinition.identifier.database.getOrElse("default")
+    val db = tableDefinition.identifier.database.getOrElse(SparkUtils.getCurrentDatabase)
     val dbDefinition = mockDbDefinition
       .getOrElse(SparkUtils.getExternalCatalog().getDatabase(db))
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -85,19 +85,20 @@ object internal extends Logging {
       clusterName: String,
       mockDbDefinition: Option[CatalogDatabase] = None): AtlasEntityWithDependencies = {
     val tableDefinition = SparkUtils.getCatalogTableIfExistent(tblDefinition)
-    val db = tableDefinition.identifier.database.getOrElse(SparkUtils.getCurrentDatabase)
+    val db = SparkUtils.getDatabaseName(tableDefinition)
+    val table = SparkUtils.getTableName(tableDefinition)
     val dbDefinition = mockDbDefinition
       .getOrElse(SparkUtils.getExternalCatalog().getDatabase(db))
 
     val dbEntity = sparkDbToEntity(dbDefinition, clusterName, tableDefinition.owner)
     val sdEntity =
-      sparkStorageFormatToEntity(tableDefinition.storage, db, tableDefinition.identifier.table)
+      sparkStorageFormatToEntity(tableDefinition.storage, db, table)
 
     val tblEntity = new AtlasEntity(metadata.TABLE_TYPE_STRING)
 
     tblEntity.setAttribute("qualifiedName",
-      sparkTableUniqueAttribute(db, tableDefinition.identifier.table))
-    tblEntity.setAttribute("name", tableDefinition.identifier.table)
+      sparkTableUniqueAttribute(db, table))
+    tblEntity.setAttribute("name", table)
     tblEntity.setAttribute("tableType", tableDefinition.tableType.name)
     tblEntity.setAttribute("schemaDesc", tableDefinition.schema.simpleString)
     tblEntity.setAttribute("provider", tableDefinition.provider.getOrElse(""))

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/utils/SparkUtils.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/utils/SparkUtils.scala
@@ -102,7 +102,7 @@ object SparkUtils extends Logging {
   def getCatalogTableIfExistent(tableDefinition: CatalogTable): CatalogTable = {
     try {
       SparkUtils.getExternalCatalog().getTable(
-        tableDefinition.identifier.database.getOrElse("default"),
+        tableDefinition.identifier.database.getOrElse(SparkUtils.getCurrentDatabase),
         tableDefinition.identifier.table)
     } catch {
       case e: Throwable =>

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/utils/SparkUtils.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/utils/SparkUtils.scala
@@ -24,6 +24,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, ExternalCatalog}
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.hive.thriftserver.HiveThriftServer2
@@ -124,7 +125,7 @@ object SparkUtils extends Logging {
    */
   // scalastyle:on
   def getDatabaseName(tableDefinition: CatalogTable): String = {
-    formatDatabaseName(tableDefinition.identifier.database.getOrElse(getCurrentDatabase))
+    getDatabaseName(tableDefinition.identifier)
   }
 
   // scalastyle:off
@@ -134,7 +135,27 @@ object SparkUtils extends Logging {
    */
   // scalastyle:on
   def getTableName(tableDefinition: CatalogTable): String = {
-    formatTableName(tableDefinition.identifier.table)
+    getTableName(tableDefinition.identifier)
+  }
+
+  // scalastyle:off
+  /**
+   * This is based on the logic how Spark handles database name (borrowed from Apache Spark v2.4.0).
+   * https://github.com/apache/spark/blob/0a4c03f7d084f1d2aa48673b99f3b9496893ce8d/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala#L294-L295
+   */
+  // scalastyle:on
+  def getDatabaseName(identifier: TableIdentifier): String = {
+    formatDatabaseName(identifier.database.getOrElse(getCurrentDatabase))
+  }
+
+  // scalastyle:off
+  /**
+   * This is based on the logic how Spark handles database name (borrowed from Apache Spark v2.4.0).
+   * https://github.com/apache/spark/blob/0a4c03f7d084f1d2aa48673b99f3b9496893ce8d/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala#L294-L295
+   */
+  // scalastyle:on
+  def getTableName(identifier: TableIdentifier): String = {
+    formatTableName(identifier.table)
   }
 
   /**

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/utils/SparkUtils.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/utils/SparkUtils.scala
@@ -89,6 +89,12 @@ object SparkUtils extends Logging {
     catalog
   }
 
+  def getCurrentDatabase: String = {
+    val database = sparkSession.sessionState.catalog.getCurrentDatabase
+    require(database != null, "current database is null")
+    database
+  }
+
   /**
    * Get the catalog table of current external catalog if exists; otherwise, it returns
    * the input catalog table as is.

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/LoadDataHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/LoadDataHarvesterSuite.scala
@@ -40,12 +40,20 @@ class LoadDataHarvesterSuite
   with WithHiveSupport
   with ProcessEntityValidator {
 
+  private val dbName = "tmpdb"
   private val sourceTblName = "source_" + Random.nextInt(100000)
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
 
+    sparkSession.sql(s"DROP DATABASE IF EXISTS $dbName Cascade")
+    sparkSession.sql(s"CREATE DATABASE $dbName")
+    sparkSession.sql(s"USE $dbName")
     sparkSession.sql(s"CREATE TABLE $sourceTblName (name string)")
+  }
+
+  override protected def afterAll(): Unit = {
+    sparkSession.sql(s"DROP DATABASE IF EXISTS $dbName Cascade")
   }
 
   test("LOAD DATA [LOCAL] INPATH path source") {
@@ -74,7 +82,7 @@ class LoadDataHarvesterSuite
       outputEntity.getTypeName should be (external.HIVE_TABLE_TYPE_STRING)
       outputEntity.getAttribute("name") should be (sourceTblName)
       outputEntity.getAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME) should be (
-        s"default.$sourceTblName@primary")
+        s"$dbName.$sourceTblName@primary")
     })
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes to use current DB name in current Spark session instead of `default` when Spark table information doesn't contain database name.

## How was this patch tested?

Modified UT. Without the change, `prepareEntity` fails to find table entity from "default" database.

Closes #246 