### PR TITLE
[SAC-248][CORE] Drop attribute `executionTime` in `spark_process`

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/SparkAtlasEventTracker.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/SparkAtlasEventTracker.scala
@@ -86,7 +86,7 @@ class SparkAtlasEventTracker(atlasClient: AtlasClient, atlasClientConf: AtlasCli
       return
     }
 
-    val qd = QueryDetail(qe, AtlasUtils.issueExecutionId(), durationNs, Option(SQLQuery.get()))
+    val qd = QueryDetail.fromQueryExecutionListener(qe, durationNs)
     executionPlanTracker.pushEvent(qd)
   }
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/SparkAtlasStreamingQueryEventTracker.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/SparkAtlasStreamingQueryEventTracker.scala
@@ -55,14 +55,12 @@ class SparkAtlasStreamingQueryEventTracker(
       if (query != null) {
         query match {
           case query: StreamingQueryWrapper =>
-            val qd = QueryDetail(query.streamingQuery.lastExecution,
-              AtlasUtils.issueExecutionId(), -1, None, Some(event.progress.sink))
+            val qd = QueryDetail.fromStreamingQueryListener(query.streamingQuery, event)
             executionPlanTracker.pushEvent(qd)
             streamQueryHashset.add(event.progress.runId)
 
           case query: StreamExecution =>
-            val qd = QueryDetail(query.lastExecution, AtlasUtils.issueExecutionId(),
-              -1, None, Some(event.progress.sink))
+            val qd = QueryDetail.fromStreamingQueryListener(query, event)
             executionPlanTracker.pushEvent(qd)
             streamQueryHashset.add(event.progress.runId)
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -210,7 +210,6 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
   private def getPlanInfo(qd: QueryDetail): Map[String, String] = {
     Map("executionId" -> qd.executionId.toString,
       "remoteUser" -> SparkUtils.currSessionUser(qd.qe),
-      "durationMs" -> qd.durationMs.toString,
       "details" -> qd.qe.toString(),
       "sparkPlanDescription" -> qd.qe.sparkPlan.toString())
   }

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/CommandsHarvester.scala
@@ -210,7 +210,7 @@ object CommandsHarvester extends AtlasEntityUtils with Logging {
   private def getPlanInfo(qd: QueryDetail): Map[String, String] = {
     Map("executionId" -> qd.executionId.toString,
       "remoteUser" -> SparkUtils.currSessionUser(qd.qe),
-      "executionTime" -> qd.executionTime.toString,
+      "durationMs" -> qd.durationMs.toString,
       "details" -> qd.qe.toString(),
       "sparkPlanDescription" -> qd.qe.sparkPlan.toString())
   }

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
@@ -40,18 +40,16 @@ import org.apache.spark.sql.streaming.StreamingQueryListener.QueryProgressEvent
 case class QueryDetail(
     qe: QueryExecution,
     executionId: Long,
-    durationMs: Long,
     query: Option[String] = None,
     sink: Option[SinkProgress] = None)
 
 object QueryDetail {
   def fromQueryExecutionListener(qe: QueryExecution, durationNs: Long): QueryDetail = {
-    val durationMs = TimeUnit.MILLISECONDS.convert(durationNs, TimeUnit.NANOSECONDS)
-    QueryDetail(qe, AtlasUtils.issueExecutionId(), durationMs, Option(SQLQuery.get()))
+    QueryDetail(qe, AtlasUtils.issueExecutionId(), Option(SQLQuery.get()))
   }
 
   def fromStreamingQueryListener(qe: StreamExecution, event: QueryProgressEvent): QueryDetail = {
-    QueryDetail(qe.lastExecution, AtlasUtils.issueExecutionId(), -1, None,
+    QueryDetail(qe.lastExecution, AtlasUtils.issueExecutionId(), None,
       Some(event.progress.sink))
   }
 }

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/AtlasEntityUtils.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/AtlasEntityUtils.scala
@@ -130,11 +130,10 @@ trait AtlasEntityUtils extends Logging {
   def processToEntity(
       qe: QueryExecution,
       executionId: Long,
-      durationMs: Long,
       inputs: List[AtlasEntity],
       outputs: List[AtlasEntity],
       query: Option[String] = None): AtlasEntityWithDependencies =
-    internal.sparkProcessToEntity(qe, executionId, durationMs, inputs, outputs, query)
+    internal.sparkProcessToEntity(qe, executionId, inputs, outputs, query)
 
   def processUniqueAttribute(executionId: Long): String =
     internal.sparkProcessUniqueAttribute(executionId)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/AtlasEntityUtils.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/AtlasEntityUtils.scala
@@ -130,11 +130,11 @@ trait AtlasEntityUtils extends Logging {
   def processToEntity(
       qe: QueryExecution,
       executionId: Long,
-      executionTime: Long,
+      durationMs: Long,
       inputs: List[AtlasEntity],
       outputs: List[AtlasEntity],
       query: Option[String] = None): AtlasEntityWithDependencies =
-    internal.sparkProcessToEntity(qe, executionId, executionTime, inputs, outputs, query)
+    internal.sparkProcessToEntity(qe, executionId, durationMs, inputs, outputs, query)
 
   def processUniqueAttribute(executionId: Long): String =
     internal.sparkProcessUniqueAttribute(executionId)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -148,7 +148,6 @@ object internal extends Logging {
   def sparkProcessToEntity(
       qe: QueryExecution,
       executionId: Long,
-      durationMs: Long,
       inputs: List[AtlasEntity],
       outputs: List[AtlasEntity],
       query: Option[String] = None): AtlasEntityWithDependencies = {
@@ -163,7 +162,6 @@ object internal extends Logging {
     entity.setAttribute("remoteUser", SparkUtils.currSessionUser(qe))
     entity.setAttribute("inputs", inputs.asJava)
     entity.setAttribute("outputs", outputs.asJava)
-    entity.setAttribute("durationMs", durationMs)
     entity.setAttribute("details", qe.toString())
     entity.setAttribute("sparkPlanDescription", qe.sparkPlan.toString())
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -148,7 +148,7 @@ object internal extends Logging {
   def sparkProcessToEntity(
       qe: QueryExecution,
       executionId: Long,
-      executionTime: Long,
+      durationMs: Long,
       inputs: List[AtlasEntity],
       outputs: List[AtlasEntity],
       query: Option[String] = None): AtlasEntityWithDependencies = {
@@ -163,7 +163,7 @@ object internal extends Logging {
     entity.setAttribute("remoteUser", SparkUtils.currSessionUser(qe))
     entity.setAttribute("inputs", inputs.asJava)
     entity.setAttribute("outputs", outputs.asJava)
-    entity.setAttribute("executionTime", executionTime)
+    entity.setAttribute("durationMs", durationMs)
     entity.setAttribute("details", qe.toString())
     entity.setAttribute("sparkPlanDescription", qe.sparkPlan.toString())
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
@@ -130,7 +130,6 @@ object metadata {
     AtlasTypeUtil.createOptionalAttrDef("executionId", new AtlasLongType),
     AtlasTypeUtil.createOptionalAttrDef("currUser", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("remoteUser", new AtlasStringType),
-    AtlasTypeUtil.createOptionalAttrDef("durationMs", new AtlasLongType),
     AtlasTypeUtil.createOptionalAttrDef("details", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("sparkPlanDescription", new AtlasStringType))
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/metadata.scala
@@ -130,7 +130,7 @@ object metadata {
     AtlasTypeUtil.createOptionalAttrDef("executionId", new AtlasLongType),
     AtlasTypeUtil.createOptionalAttrDef("currUser", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("remoteUser", new AtlasStringType),
-    AtlasTypeUtil.createOptionalAttrDef("executionTime", new AtlasLongType),
+    AtlasTypeUtil.createOptionalAttrDef("durationMs", new AtlasLongType),
     AtlasTypeUtil.createOptionalAttrDef("details", new AtlasStringType),
     AtlasTypeUtil.createOptionalAttrDef("sparkPlanDescription", new AtlasStringType))
 

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/ml/MLPipelineWithSaveIntoSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/ml/MLPipelineWithSaveIntoSuite.scala
@@ -82,7 +82,7 @@ class MLPipelineWithSaveIntoSuite extends BaseResourceIT with Matchers with With
     val qe = sparkSession.sql(s"INSERT INTO TABLE $destinationSparkTblName " +
       s"SELECT text FROM $sourceSparkTblName").queryExecution
 
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
 
     assert(qe.sparkPlan.isInstanceOf[DataWritingCommandExec])
     val node = qe.sparkPlan.asInstanceOf[DataWritingCommandExec]
@@ -133,7 +133,7 @@ class MLPipelineWithSaveIntoSuite extends BaseResourceIT with Matchers with With
     val qe = sparkSession.sql(s"INSERT INTO TABLE $destinationSparkTblName " +
       s"SELECT text FROM $sourceSparkTblName").queryExecution
 
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
 
     assert(qe.sparkPlan.isInstanceOf[DataWritingCommandExec])
     val node = qe.sparkPlan.asInstanceOf[DataWritingCommandExec]
@@ -194,7 +194,7 @@ class MLPipelineWithSaveIntoSuite extends BaseResourceIT with Matchers with With
     assert(node2.cmd.isInstanceOf[InsertIntoHadoopFsRelationCommand])
     val cmd2 = node2.cmd.asInstanceOf[InsertIntoHadoopFsRelationCommand]
 
-    val qd2 = QueryDetail(qe, 0L, 0L)
+    val qd2 = QueryDetail(qe, 0L)
     val entities2 = CommandsHarvester.InsertIntoHadoopFsRelationHarvester.harvest(cmd2, qd2)
     val pEntity2 = entities2.head.entity
 

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateDataSourceTableAsSelectHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateDataSourceTableAsSelectHarvesterSuite.scala
@@ -78,7 +78,7 @@ class CreateDataSourceTableAsSelectHarvesterSuite
     sparkSession.sessionState.catalog.createTable(
       newTable, ignoreIfExists = false, validateLocation = false)
 
-    val qd = QueryDetail(df.queryExecution, 0L, 0L)
+    val qd = QueryDetail(df.queryExecution, 0L)
     val entities = CommandsHarvester.CreateDataSourceTableAsSelectHarvester.harvest(cmd, qd)
     val processDeps = entities.head.dependencies
     val maybeEntity = processDeps.find(e => e.entity.getTypeName == "spark_table").map(_.entity)

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateHiveTableAsSelectHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateHiveTableAsSelectHarvesterSuite.scala
@@ -54,7 +54,7 @@ class CreateHiveTableAsSelectHarvesterSuite
     val destTblName = "dest1_" + Random.nextInt(100000)
     val qe = sparkSession.sql(s"CREATE TABLE $destTblName AS SELECT name FROM $sourceTblName")
       .queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
     val ctasNode = qe.sparkPlan.collect {
       case p: DataWritingCommandExec => p
       case p: LeafExecNode => p
@@ -93,7 +93,7 @@ class CreateHiveTableAsSelectHarvesterSuite
     val qe = sparkSession.sql(s"CREATE TABLE $destTblName AS " +
       s"SELECT a.age FROM $sourceTblName a, $sourceTbl1Name b WHERE a.name = b.name")
       .queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
     val ctasNode = qe.sparkPlan.collect {
       case p: DataWritingCommandExec => p
       case p: LeafExecNode => p
@@ -131,7 +131,7 @@ class CreateHiveTableAsSelectHarvesterSuite
     val destTblName = "dest3_" + Random.nextInt(100000)
     val qe = sparkSession.sql(s"CREATE TABLE $destTblName AS SELECT * FROM $viewName")
       .queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
     val ctasNode = qe.sparkPlan.collect {
       case p: DataWritingCommandExec => p
       case p: LeafExecNode => p
@@ -167,7 +167,7 @@ class CreateHiveTableAsSelectHarvesterSuite
 
     val qe = sparkSession.sql(s"CREATE TABLE $destTblName AS SELECT * " +
       s"FROM parquet.`$path`").queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
     val ctasNode = qe.sparkPlan.collect {
       case p: DataWritingCommandExec => p
       case p: LeafExecNode => p

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateViewHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/CreateViewHarvesterSuite.scala
@@ -44,7 +44,7 @@ class CreateViewHarvesterSuite
   test("CREATE VIEW FROM TABLE") {
     val qe = sparkSession.sql(s"CREATE VIEW $destinationViewName " +
       s"AS SELECT * FROM $sourceTblName").queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
 
     assert(qe.sparkPlan.isInstanceOf[ExecutedCommandExec])
     val node = qe.sparkPlan.asInstanceOf[ExecutedCommandExec]
@@ -71,7 +71,7 @@ class CreateViewHarvesterSuite
   test("CREATE VIEW without source") {
     val qe = sparkSession.sql(s"CREATE VIEW $destinationViewName2 " +
       s"AS SELECT 1").queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
 
     assert(qe.sparkPlan.isInstanceOf[ExecutedCommandExec])
     val node = qe.sparkPlan.asInstanceOf[ExecutedCommandExec]

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHarvesterSuite.scala
@@ -88,7 +88,7 @@ class InsertIntoHarvesterSuite
   test("INSERT INTO HIVE TABLE FROM HIVE TABLE") {
     val qe = sparkSession.sql(s"INSERT INTO TABLE $destinationHiveTblName " +
       s"SELECT * FROM $sourceHiveTblName").queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
 
     assert(qe.sparkPlan.isInstanceOf[DataWritingCommandExec])
     val node = qe.sparkPlan.asInstanceOf[DataWritingCommandExec]
@@ -116,7 +116,7 @@ class InsertIntoHarvesterSuite
   test("INSERT INTO HIVE TABLE FROM HIVE TABLE (Cyclic)") {
     val qe = sparkSession.sql(s"INSERT INTO TABLE $destinationHiveTblName " +
       s"SELECT * FROM $destinationHiveTblName").queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
 
     assert(qe.sparkPlan.isInstanceOf[DataWritingCommandExec])
     val node = qe.sparkPlan.asInstanceOf[DataWritingCommandExec]
@@ -139,7 +139,7 @@ class InsertIntoHarvesterSuite
   test("INSERT INTO HIVE TABLE FROM SPARK TABLE") {
     val qe = sparkSession.sql(s"INSERT INTO TABLE $destinationHiveTblName " +
       s"SELECT * FROM $sourceSparkTblName").queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
 
     assert(qe.sparkPlan.isInstanceOf[DataWritingCommandExec])
     val node = qe.sparkPlan.asInstanceOf[DataWritingCommandExec]
@@ -167,7 +167,7 @@ class InsertIntoHarvesterSuite
   test("INSERT INTO SPARK TABLE FROM HIVE TABLE") {
     val qe = sparkSession.sql(s"INSERT INTO TABLE $destinationSparkTblName " +
       s"SELECT * FROM $sourceHiveTblName").queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
 
     assert(qe.sparkPlan.isInstanceOf[DataWritingCommandExec])
     val node = qe.sparkPlan.asInstanceOf[DataWritingCommandExec]
@@ -195,7 +195,7 @@ class InsertIntoHarvesterSuite
   test("INSERT INTO SPARK TABLE FROM SPARK TABLE") {
     val qe = sparkSession.sql(s"INSERT INTO TABLE $destinationSparkTblName " +
       s"SELECT * FROM $sourceSparkTblName").queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
 
     assert(qe.sparkPlan.isInstanceOf[DataWritingCommandExec])
     val node = qe.sparkPlan.asInstanceOf[DataWritingCommandExec]
@@ -223,7 +223,7 @@ class InsertIntoHarvesterSuite
   test("INSERT INTO SPARK TABLE FROM SPARK TABLE (Cyclic)") {
     val qe = sparkSession.sql(s"INSERT INTO TABLE $destinationSparkTblName " +
       s"SELECT * FROM $destinationSparkTblName").queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
 
     assert(qe.sparkPlan.isInstanceOf[DataWritingCommandExec])
     val node = qe.sparkPlan.asInstanceOf[DataWritingCommandExec]
@@ -247,7 +247,7 @@ class InsertIntoHarvesterSuite
     val qe = sparkSession.sql(s"INSERT INTO $bigTable " +
       s"SELECT * FROM $inputTable1, $inputTable2, $inputTable3 " +
       s"where $inputTable1.a = $inputTable2.b AND $inputTable1.a = $inputTable3.c").queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
 
     assert(qe.sparkPlan.isInstanceOf[DataWritingCommandExec])
     val node = qe.sparkPlan.asInstanceOf[DataWritingCommandExec]
@@ -278,7 +278,7 @@ class InsertIntoHarvesterSuite
       s"INSERT INTO TABLE $outputTable1 SELECT $bigTable.a " +
       s"INSERT INTO TABLE $outputTable2 SELECT $bigTable.b " +
       s"INSERT into TABLE $outputTable3 SELECT $bigTable.c").queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
 
     assert(qe.sparkPlan.isInstanceOf[UnionExec])
     qe.sparkPlan.asInstanceOf[UnionExec]
@@ -314,7 +314,7 @@ class InsertIntoHarvesterSuite
       s"FROM view1 INSERT INTO TABLE $outputTable1 SELECT view1.a " +
       s"INSERT INTO TABLE $outputTable2 SELECT view1.b " +
       s"INSERT into TABLE $outputTable3 SELECT view1.c").queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
 
     assert(qe.sparkPlan.isInstanceOf[UnionExec])
     qe.sparkPlan.asInstanceOf[UnionExec]

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHiveDirHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/InsertIntoHiveDirHarvesterSuite.scala
@@ -47,7 +47,7 @@ class InsertIntoHiveDirHarvesterSuite
   test("INSERT OVERWRITE DIRECTORY path...") {
     val qe = sparkSession.sql(s"INSERT OVERWRITE DIRECTORY 'target/dir1' " +
       s"SELECT * FROM $sourceTblName").queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
 
     assert(qe.sparkPlan.isInstanceOf[DataWritingCommandExec])
     val node = qe.sparkPlan.asInstanceOf[DataWritingCommandExec]

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/LoadDataHarvesterSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/LoadDataHarvesterSuite.scala
@@ -56,7 +56,7 @@ class LoadDataHarvesterSuite
 
     val qe = sparkSession.sql(s"LOAD DATA LOCAL INPATH '${file.getAbsolutePath}' " +
       s"OVERWRITE INTO  TABLE $sourceTblName").queryExecution
-    val qd = QueryDetail(qe, 0L, 0L)
+    val qd = QueryDetail(qe, 0L)
     val node = qe.sparkPlan.collect { case p: LeafExecNode => p }
     assert(node.size == 1)
     val execNode = node.head.asInstanceOf[ExecutedCommandExec]

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForBatchQuerySuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForBatchQuerySuite.scala
@@ -418,7 +418,6 @@ class SparkExecutionPlanProcessorForBatchQuerySuite
     val expectedMap = Map(
       "executionId" -> queryDetail.executionId.toString,
       "remoteUser" -> SparkUtils.currSessionUser(queryDetail.qe),
-      "durationMs" -> queryDetail.durationMs.toString,
       "details" -> queryDetail.qe.toString()
     )
 

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForBatchQuerySuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForBatchQuerySuite.scala
@@ -418,7 +418,7 @@ class SparkExecutionPlanProcessorForBatchQuerySuite
     val expectedMap = Map(
       "executionId" -> queryDetail.executionId.toString,
       "remoteUser" -> SparkUtils.currSessionUser(queryDetail.qe),
-      "executionTime" -> queryDetail.executionTime.toString,
+      "durationMs" -> queryDetail.durationMs.toString,
       "details" -> queryDetail.qe.toString()
     )
 

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
@@ -636,7 +636,7 @@ class SparkExecutionPlanProcessorForStreamingQuerySuite
       val expectedMap = Map(
         "executionId" -> queryDetail.executionId.toString,
         "remoteUser" -> SparkUtils.currSessionUser(queryDetail.qe),
-        "executionTime" -> queryDetail.executionTime.toString,
+        "durationMs" -> queryDetail.durationMs.toString,
         "details" -> queryDetail.qe.toString()
       )
 

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
@@ -636,7 +636,6 @@ class SparkExecutionPlanProcessorForStreamingQuerySuite
       val expectedMap = Map(
         "executionId" -> queryDetail.executionId.toString,
         "remoteUser" -> SparkUtils.currSessionUser(queryDetail.qe),
-        "durationMs" -> queryDetail.durationMs.toString,
         "details" -> queryDetail.qe.toString()
       )
 

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/AtlasQueryExecutionListener.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/AtlasQueryExecutionListener.scala
@@ -17,7 +17,6 @@
 
 package com.hortonworks.spark.atlas.sql.testhelper
 
-import com.hortonworks.spark.atlas.AtlasUtils
 import com.hortonworks.spark.atlas.sql.QueryDetail
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.util.QueryExecutionListener
@@ -32,7 +31,7 @@ class AtlasQueryExecutionListener extends QueryExecutionListener {
       // streaming query will be tracked via SparkAtlasStreamingQueryEventTracker
       return
     }
-    queryDetails += QueryDetail(qe, AtlasUtils.issueExecutionId(), durationNs)
+    queryDetails += QueryDetail.fromQueryExecutionListener(qe, durationNs)
   }
 
   override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/AtlasStreamingQueryProgressListener.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/AtlasStreamingQueryProgressListener.scala
@@ -17,7 +17,6 @@
 
 package com.hortonworks.spark.atlas.sql.testhelper
 
-import com.hortonworks.spark.atlas.AtlasUtils
 import com.hortonworks.spark.atlas.sql.QueryDetail
 import com.hortonworks.spark.atlas.utils.Logging
 import org.apache.spark.sql.SparkSession
@@ -39,13 +38,11 @@ class AtlasStreamingQueryProgressListener extends StreamingQueryListener with Lo
     if (query != null) {
       query match {
         case query: StreamingQueryWrapper =>
-          val qd = QueryDetail(query.streamingQuery.lastExecution,
-            AtlasUtils.issueExecutionId(), -1, sink = Some(event.progress.sink))
+          val qd = QueryDetail.fromStreamingQueryListener(query.streamingQuery, event)
           queryDetails += qd
 
         case query: StreamExecution =>
-          val qd = QueryDetail(query.lastExecution, AtlasUtils.issueExecutionId(), -1,
-            sink = Some(event.progress.sink))
+          val qd = QueryDetail.fromStreamingQueryListener(query, event)
           queryDetails += qd
 
         case _ => logWarn(s"Unexpected type of streaming query: ${query.getClass}")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes dropping `executionTime` attribute as `executionTime` attribute actually simply doesn't make sense for `spark_process` - `spark_process` is assigned per application, whereas Spark provides the value per query.

## How was this patch tested?

UTs. The code change is obvious so didn't do manual tests.

This closes #248 