### PR TITLE
[SAC-253][SQL] Streaming query should evaluate all events from streaming listener, but should update efficiently

### DIFF
--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasEntityCreationRequestHelper.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/AtlasEntityCreationRequestHelper.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas
+
+import java.util.UUID
+
+import com.hortonworks.spark.atlas.types.metadata
+import com.hortonworks.spark.atlas.utils.Logging
+import org.apache.atlas.model.instance.AtlasObjectId
+
+import scala.collection.mutable
+
+class AtlasEntityCreationRequestHelper(
+    atlasClient: AtlasClient) extends Logging {
+  // query to (inputs, outputs)
+  private val queryToInputsAndOutputs = new mutable.HashMap[UUID,
+    (Set[AtlasObjectId], Set[AtlasObjectId])]()
+
+  def requestCreation(entities: Seq[SACAtlasReferenceable], runId: Option[UUID] = None): Unit = {
+    runId match {
+      case Some(rid) => updateEntitiesForStreamingQuery(rid, entities)
+      case None => updateEntitiesForBatchQuery(entities)
+    }
+  }
+
+  private def updateEntitiesForBatchQuery(entities: Seq[SACAtlasReferenceable]): Unit = {
+    // the query is batch, hence always create entities
+    // create input/output entities as well as update process entity(-ies)
+    createEntities(entities)
+  }
+
+  private def updateEntitiesForStreamingQuery(
+      runId: UUID,
+      entities: Seq[SACAtlasReferenceable]): Unit = {
+    // the query is streaming, so which partial of source/sink entities can be seen
+    // in specific batch - need to accumulate efficiently
+    val processes = entities
+      .filter(en => en.typeName == metadata.PROCESS_TYPE_STRING
+        && en.isInstanceOf[SACAtlasEntityWithDependencies])
+      .map(_.asInstanceOf[SACAtlasEntityWithDependencies])
+
+    val inputs = processes.flatMap { p =>
+      AtlasEntityReadHelper.getSeqAtlasObjectIdAttribute(p.entity, "inputs")
+    }.toSet
+
+    val outputs = processes.flatMap { p =>
+      AtlasEntityReadHelper.getSeqAtlasObjectIdAttribute(p.entity, "outputs")
+    }.toSet
+
+    queryToInputsAndOutputs.get(runId) match {
+      case Some((is, os)) if !inputs.subsetOf(is) || !outputs.subsetOf(os) =>
+        // The query is streaming, and at least either inputs or outputs is not a
+        // subset of accumulated one.
+
+        // NOTE: we leverage the 'process' model's definition:
+        // inputs and outputs are defined as set in definition, and Atlas automatically
+        // accumulate these values which doesn't require us to track all inputs and
+        // outputs and always provide accumulated one.
+        // If we need to do in our own, we should also accumulate inputs and outputs
+        // in SparkCatalogEventProcessor and maintain full of inputs and outputs.
+        // Here we only accumulate inputs/outputs for each streaming query (runId).
+
+        createEntities(entities)
+
+        // update inputs and outputs as accumulating current one and new inputs/outputs
+        updateInputsAndOutputs(runId, is.union(inputs), os.union(outputs))
+
+      case Some((_, _)) => // if inputs.subsetOf(is) && outputs.subsetOf(os)
+      // we already updated superset of inputs/outputs, skip updating
+
+      case _ =>
+        // the streaming query hasn't been examined in current session
+        createEntities(entities)
+
+        // update inputs and outputs as new inputs/outputs, as there's nothing to accumulate
+        updateInputsAndOutputs(runId, inputs, outputs)
+    }
+  }
+
+  private def createEntities(entities: Seq[SACAtlasReferenceable]): Unit = {
+    // create input/output entities as well as update process entity(-ies)
+    atlasClient.createEntitiesWithDependencies(entities)
+    logDebug(s"Created entities without columns")
+  }
+
+  private def updateInputsAndOutputs(
+      runId: UUID,
+      newInputs: Set[AtlasObjectId],
+      newOutputs: Set[AtlasObjectId]): Unit = {
+    queryToInputsAndOutputs.put(runId, (newInputs, newOutputs))
+  }
+}

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
@@ -47,7 +47,7 @@ case class QueryDetail(
     executionId: Long,
     query: Option[String] = None,
     sink: Option[SinkProgress] = None,
-    runId: Option[UUID] = None)
+    queryId: Option[UUID] = None)
 
 object QueryDetail {
   def fromQueryExecutionListener(qe: QueryExecution, durationNs: Long): QueryDetail = {
@@ -56,7 +56,7 @@ object QueryDetail {
 
   def fromStreamingQueryListener(qe: StreamExecution, event: QueryProgressEvent): QueryDetail = {
     QueryDetail(qe.lastExecution, AtlasUtils.issueExecutionId(), None,
-      Some(event.progress.sink), Some(qe.runId))
+      Some(event.progress.sink), Some(qe.id))
   }
 }
 
@@ -164,7 +164,7 @@ class SparkExecutionPlanProcessor(
       }
     }
 
-    createReqHelper.requestCreation(entities, qd.runId)
+    createReqHelper.requestCreation(entities, qd.queryId)
   }
 }
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessor.scala
@@ -17,6 +17,7 @@
 
 package com.hortonworks.spark.atlas.sql
 
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 import com.hortonworks.spark.atlas.sql.CommandsHarvester.WriteToDataSourceV2Harvester
@@ -28,20 +29,25 @@ import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec
 import org.apache.spark.sql.execution.streaming.sources.MicroBatchWriter
 import org.apache.spark.sql.hive.execution._
 import org.apache.spark.sql.sources.v2.writer.{DataWriterFactory, WriterCommitMessage}
-import com.hortonworks.spark.atlas.{AbstractEventProcessor, AtlasClient, AtlasClientConf, AtlasUtils}
+import com.hortonworks.spark.atlas._
+import com.hortonworks.spark.atlas.types.metadata
 import com.hortonworks.spark.atlas.utils.Logging
+import org.apache.atlas.model.instance.AtlasObjectId
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.streaming.StreamExecution
 import org.apache.spark.sql.sources.v2.writer.streaming.StreamWriter
 import org.apache.spark.sql.streaming.SinkProgress
 import org.apache.spark.sql.streaming.StreamingQueryListener.QueryProgressEvent
 
+import scala.collection.mutable
+
 
 case class QueryDetail(
     qe: QueryExecution,
     executionId: Long,
     query: Option[String] = None,
-    sink: Option[SinkProgress] = None)
+    sink: Option[SinkProgress] = None,
+    runId: Option[UUID] = None)
 
 object QueryDetail {
   def fromQueryExecutionListener(qe: QueryExecution, durationNs: Long): QueryDetail = {
@@ -50,7 +56,7 @@ object QueryDetail {
 
   def fromStreamingQueryListener(qe: StreamExecution, event: QueryProgressEvent): QueryDetail = {
     QueryDetail(qe.lastExecution, AtlasUtils.issueExecutionId(), None,
-      Some(event.progress.sink))
+      Some(event.progress.sink), Some(qe.runId))
   }
 }
 
@@ -58,6 +64,8 @@ class SparkExecutionPlanProcessor(
     private[atlas] val atlasClient: AtlasClient,
     val conf: AtlasClientConf)
   extends AbstractEventProcessor[QueryDetail] with Logging {
+
+  val createReqHelper = new AtlasEntityCreationRequestHelper(atlasClient)
 
   // TODO: We should handle OVERWRITE to remove the old lineage.
   // TODO: We should consider LLAPRelation later
@@ -145,19 +153,18 @@ class SparkExecutionPlanProcessor(
         //        if (r.relation.getClass.getCanonicalName.endsWith("dd")) =>
         //      println("close hive connection via " + r.relation.getClass.getCanonicalName)
 
-      } ++ {
-        qd.qe.sparkPlan match {
-          case d: DataWritingCommandExec if d.cmd.isInstanceOf[InsertIntoHiveDirCommand] =>
-            CommandsHarvester.InsertIntoHiveDirHarvester.harvest(
-              d.cmd.asInstanceOf[InsertIntoHiveDirCommand], qd)
+    } ++ {
+      qd.qe.sparkPlan match {
+        case d: DataWritingCommandExec if d.cmd.isInstanceOf[InsertIntoHiveDirCommand] =>
+          CommandsHarvester.InsertIntoHiveDirHarvester.harvest(
+            d.cmd.asInstanceOf[InsertIntoHiveDirCommand], qd)
 
-          case _ =>
-            Seq.empty
-        }
+        case _ =>
+          Seq.empty
       }
+    }
 
-      atlasClient.createEntitiesWithDependencies(entities)
-      logDebug(s"Created entities without columns")
+    createReqHelper.requestCreation(entities, qd.runId)
   }
 }
 

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/internal.scala
@@ -179,9 +179,9 @@ object internal extends Logging {
   }
 
   def etlProcessToEntity(
-                          inputs: Seq[SACAtlasReferenceable],
-                          outputs: Seq[SACAtlasReferenceable],
-                          logMap: Map[String, String]): SACAtlasEntityWithDependencies = {
+      inputs: Seq[SACAtlasReferenceable],
+      outputs: Seq[SACAtlasReferenceable],
+      logMap: Map[String, String]): SACAtlasEntityWithDependencies = {
     val entity = new AtlasEntity(metadata.PROCESS_TYPE_STRING)
 
     val appId = SparkUtils.sparkSession.sparkContext.applicationId
@@ -204,9 +204,9 @@ object internal extends Logging {
   }
 
   def updateMLProcessToEntity(
-                               inputs: Seq[SACAtlasReferenceable],
-                               outputs: Seq[SACAtlasReferenceable],
-                               logMap: Map[String, String]): SACAtlasEntityWithDependencies = {
+      inputs: Seq[SACAtlasReferenceable],
+      outputs: Seq[SACAtlasReferenceable],
+      logMap: Map[String, String]): SACAtlasEntityWithDependencies = {
 
     val model_uid = internal.cachedObjects("model_uid").asInstanceOf[String]
     val modelEntity = internal.cachedObjects(s"${model_uid}_modelEntity").

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/AtlasEntityCreationRequestHelperSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/AtlasEntityCreationRequestHelperSuite.scala
@@ -40,7 +40,7 @@ class AtlasEntityCreationRequestHelperSuite
 
   test("SAC-253 partial sources presented in streaming query") {
     val cluster = "cl1"
-    val runId = UUID.randomUUID()
+    val queryId = UUID.randomUUID()
 
     val topic1 = KafkaTopicInformation("topic1")
     val topic2 = KafkaTopicInformation("topic2")
@@ -53,33 +53,35 @@ class AtlasEntityCreationRequestHelperSuite
     val sink = external.kafkaToEntity(cluster, topicSink)
 
     // source1
-    validateInputsOutputs(runId, Seq(source1), Seq(sink), expectNoCreationRequest = false)
+    validateInputsOutputs(queryId, Seq(source1), Seq(sink), expectNoCreationRequest = false)
 
     client.clearEntities()
 
     // source1, source2
-    validateInputsOutputs(runId, Seq(source1, source2), Seq(sink), expectNoCreationRequest = false)
+    validateInputsOutputs(queryId, Seq(source1, source2), Seq(sink),
+      expectNoCreationRequest = false)
 
     client.clearEntities()
 
     // source2, source3
-    validateInputsOutputs(runId, Seq(source2, source3), Seq(sink), expectNoCreationRequest = false)
+    validateInputsOutputs(queryId, Seq(source2, source3), Seq(sink),
+      expectNoCreationRequest = false)
 
     client.clearEntities()
 
     // source1, source2
-    validateInputsOutputs(runId, Seq(source1, source2), Seq(sink), expectNoCreationRequest = true)
+    validateInputsOutputs(queryId, Seq(source1, source2), Seq(sink), expectNoCreationRequest = true)
 
     client.clearEntities()
 
     // source1, source2, source3
-    validateInputsOutputs(runId, Seq(source1, source2, source3), Seq(sink),
+    validateInputsOutputs(queryId, Seq(source1, source2, source3), Seq(sink),
       expectNoCreationRequest = true)
   }
 
   test("SAC-253 partial sinks presented in streaming query") {
     val cluster = "cl1"
-    val runId = UUID.randomUUID()
+    val queryId = UUID.randomUUID()
 
     val topic1 = KafkaTopicInformation("topic1")
     val topic2 = KafkaTopicInformation("topic2")
@@ -92,37 +94,37 @@ class AtlasEntityCreationRequestHelperSuite
     val sink3 = external.kafkaToEntity(cluster, topic3)
 
     // sink1
-    validateInputsOutputs(runId, Seq(source), Seq(sink1), expectNoCreationRequest = false)
+    validateInputsOutputs(queryId, Seq(source), Seq(sink1), expectNoCreationRequest = false)
 
     client.clearEntities()
 
     // sink1, sink2
-    validateInputsOutputs(runId, Seq(source), Seq(sink1, sink2), expectNoCreationRequest = false)
+    validateInputsOutputs(queryId, Seq(source), Seq(sink1, sink2), expectNoCreationRequest = false)
 
     client.clearEntities()
 
     // sink2, sink3
-    validateInputsOutputs(runId, Seq(source), Seq(sink2, sink3), expectNoCreationRequest = false)
+    validateInputsOutputs(queryId, Seq(source), Seq(sink2, sink3), expectNoCreationRequest = false)
 
     client.clearEntities()
 
     // sink1, sink2
-    validateInputsOutputs(runId, Seq(source), Seq(sink1, sink2), expectNoCreationRequest = true)
+    validateInputsOutputs(queryId, Seq(source), Seq(sink1, sink2), expectNoCreationRequest = true)
 
     client.clearEntities()
 
     // sink1, sink2, sink3
-    validateInputsOutputs(runId, Seq(source), Seq(sink1, sink2, sink3),
+    validateInputsOutputs(queryId, Seq(source), Seq(sink1, sink2, sink3),
       expectNoCreationRequest = true)
   }
 
   private def validateInputsOutputs(
-      runId: UUID,
+      queryId: UUID,
       sources: Seq[SACAtlasEntityWithDependencies],
       sinks: Seq[SACAtlasEntityWithDependencies],
       expectNoCreationRequest: Boolean): Unit = {
     val process = internal.etlProcessToEntity(sources, sinks, Map())
-    sut.requestCreation(Seq(process), Some(runId))
+    sut.requestCreation(Seq(process), Some(queryId))
 
     if (expectNoCreationRequest) {
       // no entities will be created, as both inputs and outputs are subset of

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/AtlasEntityCreationRequestHelperSuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/AtlasEntityCreationRequestHelperSuite.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas
+
+import java.util.UUID
+
+import com.hortonworks.spark.atlas.sql.KafkaTopicInformation
+import com.hortonworks.spark.atlas.sql.testhelper.CreateEntitiesTrackingAtlasClient
+import com.hortonworks.spark.atlas.types.{external, internal}
+import org.apache.atlas.model.instance.AtlasEntity
+import org.scalatest.{BeforeAndAfterEach, FunSuite}
+
+class AtlasEntityCreationRequestHelperSuite
+  extends FunSuite
+  with WithHiveSupport
+  with BeforeAndAfterEach {
+
+  private val client = new CreateEntitiesTrackingAtlasClient
+  private var sut: AtlasEntityCreationRequestHelper = _
+
+  override protected def beforeEach(): Unit = {
+    client.clearEntities()
+    sut = new AtlasEntityCreationRequestHelper(client)
+  }
+
+  test("SAC-253 partial sources presented in streaming query") {
+    val cluster = "cl1"
+    val runId = UUID.randomUUID()
+
+    val topic1 = KafkaTopicInformation("topic1")
+    val topic2 = KafkaTopicInformation("topic2")
+    val topic3 = KafkaTopicInformation("topic3")
+    val topicSink = KafkaTopicInformation("topicSink")
+
+    val source1 = external.kafkaToEntity(cluster, topic1)
+    val source2 = external.kafkaToEntity(cluster, topic2)
+    val source3 = external.kafkaToEntity(cluster, topic3)
+    val sink = external.kafkaToEntity(cluster, topicSink)
+
+    // source1
+    validateInputsOutputs(runId, Seq(source1), Seq(sink), expectNoCreationRequest = false)
+
+    client.clearEntities()
+
+    // source1, source2
+    validateInputsOutputs(runId, Seq(source1, source2), Seq(sink), expectNoCreationRequest = false)
+
+    client.clearEntities()
+
+    // source2, source3
+    validateInputsOutputs(runId, Seq(source2, source3), Seq(sink), expectNoCreationRequest = false)
+
+    client.clearEntities()
+
+    // source1, source2
+    validateInputsOutputs(runId, Seq(source1, source2), Seq(sink), expectNoCreationRequest = true)
+
+    client.clearEntities()
+
+    // source1, source2, source3
+    validateInputsOutputs(runId, Seq(source1, source2, source3), Seq(sink),
+      expectNoCreationRequest = true)
+  }
+
+  test("SAC-253 partial sinks presented in streaming query") {
+    val cluster = "cl1"
+    val runId = UUID.randomUUID()
+
+    val topic1 = KafkaTopicInformation("topic1")
+    val topic2 = KafkaTopicInformation("topic2")
+    val topic3 = KafkaTopicInformation("topic3")
+    val topicSource = KafkaTopicInformation("topicSource")
+
+    val source = external.kafkaToEntity(cluster, topicSource)
+    val sink1 = external.kafkaToEntity(cluster, topic1)
+    val sink2 = external.kafkaToEntity(cluster, topic2)
+    val sink3 = external.kafkaToEntity(cluster, topic3)
+
+    // sink1
+    validateInputsOutputs(runId, Seq(source), Seq(sink1), expectNoCreationRequest = false)
+
+    client.clearEntities()
+
+    // sink1, sink2
+    validateInputsOutputs(runId, Seq(source), Seq(sink1, sink2), expectNoCreationRequest = false)
+
+    client.clearEntities()
+
+    // sink2, sink3
+    validateInputsOutputs(runId, Seq(source), Seq(sink2, sink3), expectNoCreationRequest = false)
+
+    client.clearEntities()
+
+    // sink1, sink2
+    validateInputsOutputs(runId, Seq(source), Seq(sink1, sink2), expectNoCreationRequest = true)
+
+    client.clearEntities()
+
+    // sink1, sink2, sink3
+    validateInputsOutputs(runId, Seq(source), Seq(sink1, sink2, sink3),
+      expectNoCreationRequest = true)
+  }
+
+  private def validateInputsOutputs(
+      runId: UUID,
+      sources: Seq[SACAtlasEntityWithDependencies],
+      sinks: Seq[SACAtlasEntityWithDependencies],
+      expectNoCreationRequest: Boolean): Unit = {
+    val process = internal.etlProcessToEntity(sources, sinks, Map())
+    sut.requestCreation(Seq(process), Some(runId))
+
+    if (expectNoCreationRequest) {
+      // no entities will be created, as both inputs and outputs are subset of
+      // accumulated inputs and outputs
+      assert(client.createdEntities.isEmpty)
+    } else {
+      val allEntities = sources ++ sinks ++ Seq(process)
+      assert(client.createdEntities.length === allEntities.length)
+      assert(client.createdEntities.toSet === allEntities.map(_.entity).toSet)
+    }
+  }
+}

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/SparkExecutionPlanProcessorForStreamingQuerySuite.scala
@@ -183,6 +183,72 @@ class SparkExecutionPlanProcessorForStreamingQuerySuite
     }
   }
 
+  test("SAC-253 Kafka source(s) to kafka sink - micro-batch query" +
+    " - activating one topic per each batch") {
+    val topicPrefix = "sparkread0"
+    val brokerAddress = testUtils.brokerAddress
+
+    val customClusterName1 = "customCluster1"
+    val (df1, topicsToRead1WithClusterInfo) =
+      kafkaDfSubscribePattern(topicPrefix, customClusterName1, brokerAddress)
+
+    val customClusterName2 = "customCluster2"
+    val (df2, topicsToRead2WithClusterInfo) =
+      kafkaDfSubscribe(topicPrefix, customClusterName2, brokerAddress)
+
+    val customClusterName3 = "customCluster3"
+    val (df3, topicsToRead3WithClusterInfo) =
+      kafkaDfAssign(topicPrefix, customClusterName3, brokerAddress)
+
+    val topicsInfoToRead = topicsToRead1WithClusterInfo ++ topicsToRead2WithClusterInfo ++
+      topicsToRead3WithClusterInfo
+    val topicsToRead = topicsInfoToRead.map(_.topicName)
+
+    val topicToWrite = "sparkwrite"
+    val topics = topicsToRead ++ Seq(topicToWrite)
+
+    topics.toSet[String].foreach { ti =>
+      testUtils.createTopic(ti, 10, overwrite = true)
+    }
+
+    val (_, _, checkpointDir) = createTempDirectories
+
+    val df = df1.union(df2).union(df3)
+
+    val customClusterNameForWriter = "customCluster4"
+    val query = toKafkaSink(df, brokerAddress, Some(customClusterNameForWriter),
+      topicToWrite, checkpointDir.getAbsolutePath.toString)
+
+    try {
+      topicsInfoToRead.foreach { topicInfo =>
+        sendMessages(Seq(topicInfo.topicName))
+        waitForBatchCompleted(query)
+
+        // clearing tracking entities to verify created entities per batch
+        atlasClient.clearEntities()
+
+        val (queryDetails, entitySet) = processQueryDetails
+        // spark_process, topic to write, topic to read (only one will be captured here)
+        assert(entitySet.size === 3)
+
+        val topicToWriteWithClusterInfo = KafkaTopicInformation(topicToWrite,
+          Some(customClusterNameForWriter))
+
+        val topicsWithClusterInfo = Seq(topicInfo) ++ Seq(topicToWriteWithClusterInfo)
+
+        assertEntitiesKafkaTopicType(topicsWithClusterInfo, entitySet)
+
+        assertEntitySparkProcessType(entitySet, queryDetails, inputs => {
+          assertKafkaTopicEntities(Seq(topicInfo), inputs)
+        }, outputs => {
+          assertKafkaTopicEntities(Seq(topicToWriteWithClusterInfo), outputs)
+        })
+      }
+    } finally {
+      query.stop()
+    }
+  }
+
   test("kafka source to file sink - micro-batch query") {
     val topicPrefix = "sparkread1"
     val brokerAddress = testUtils.brokerAddress

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/KafkaTopicEntityValidator.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/sql/testhelper/KafkaTopicEntityValidator.scala
@@ -48,6 +48,13 @@ trait KafkaTopicEntityValidator extends FunSuite {
       expectedQualifiedNames)
   }
 
+  def assertKafkaTopicEntities(
+      topics: Seq[KafkaTopicInformation], entities: Seq[AtlasEntity]): Unit = {
+    assert(
+      topics.map(KafkaTopicInformation.getQualifiedName(_, "primary")).toSet ===
+      entities.map(getStringAttribute(_, "qualifiedName")).toSet)
+  }
+
   def assertEntitiesAreSubsetOfTopics(
       topics: Seq[KafkaTopicInformation], entities: Seq[AtlasEntity]): Unit = {
     TestUtils.assertSubsetOf(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Please refer #253 to see rationalization of this patch.

This patch proposes to evaluate all streaming events from streaming listener to capture late activated sources and sinks in streaming query. This change will incur huge requests to Atlas (at least one per batch), so this patch also introduces some optimization on sending request to Atlas.

The approach of optimization is memorizing accumulated inputs and outputs per streaming query and only sending request when either new inputs or new outputs is not a subset of accumulated inputs or outputs.

## How was this patch tested?

Added UTs

* UTs for class doing optimization
* another UT for simulating late source activation on streaming query

(skipping manual tests since one of new UT plays like acceptance test.)

This closes #253 