### PR TITLE
[SAC-256][BUILD] Exclude Hadoop dependencies from Beeju

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,12 @@
       <artifactId>beeju</artifactId>
       <version>1.3.1</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes to exclude Hadoop dependencies from Beeju and leverages Hadoop dependencies from Spark. (Beeju is in "test" scope, which won't make problem in usage.)

The base ground of this decision is, if Hadoop version conflict occurs between Beeju and Spark, we should rely on Spark which cannot be replaceable.

## How was this patch tested?

Existing UTs.

Closes #256 