### PR TITLE
[SAC-263][CORE] Qualify path with Spark default filesystem when scheme is not specified

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minicluster</artifactId>
+      <version>2.6.5</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
       <version>1.12.5</version>

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -125,7 +125,8 @@ object external {
     // Path.makeQualified always converts the path as absolute path, but for file scheme
     // it provides different prefix.
     // (It provides prefix as "file" instead of "file://", which both are actually valid.)
-    // Given we have been providing it as "file://", we will keep this as it is.
+    // Given we have been providing it as "file://", the logic below changes the scheme of
+    // type "file" to "file://".
     if (qUri.getScheme == "file") {
       // make sure to handle if the path has a fragment (applies to yarn
       // distributed cache)

--- a/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
+++ b/spark-atlas-connector/src/main/scala/com/hortonworks/spark/atlas/types/external.scala
@@ -121,6 +121,11 @@ object external {
     }
 
     val qUri = qualifiedPath(path).toUri
+
+    // Path.makeQualified always converts the path as absolute path, but for file scheme
+    // it provides different prefix.
+    // (It provides prefix as "file" instead of "file://", which both are actually valid.)
+    // Given we have been providing it as "file://", we will keep this as it is.
     if (qUri.getScheme == "file") {
       // make sure to handle if the path has a fragment (applies to yarn
       // distributed cache)

--- a/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/WithHDFSSupport.scala
+++ b/spark-atlas-connector/src/test/scala/com/hortonworks/spark/atlas/WithHDFSSupport.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.atlas
+
+import java.io.File
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FileUtil
+import org.apache.hadoop.hdfs.MiniDFSCluster
+import org.apache.spark.sql.SparkSession
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+trait WithHDFSSupport extends BeforeAndAfterAll { self: Suite =>
+
+  protected var sparkSession: SparkSession = _
+
+  private var hdfsCluster: MiniDFSCluster = _
+  protected var hdfsURI: String = _
+
+  private def cleanupAnyExistingSession(): Unit = {
+    val session = SparkSession.getActiveSession.orElse(SparkSession.getDefaultSession)
+    if (session.isDefined) {
+      session.get.sessionState.catalog.reset()
+      session.get.stop()
+      SparkSession.clearActiveSession()
+      SparkSession.clearDefaultSession()
+    }
+  }
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+
+    cleanupAnyExistingSession()
+
+    val baseDir = new File("./target/hdfs/").getAbsoluteFile()
+    FileUtil.fullyDelete(baseDir)
+
+    val conf = new Configuration()
+    conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath())
+    val builder = new MiniDFSCluster.Builder(conf)
+
+    hdfsCluster = builder.build()
+    hdfsURI = s"hdfs://localhost:${hdfsCluster.getNameNodePort()}/"
+
+    sparkSession = SparkSession.builder()
+      .master("local")
+      .appName(this.getClass.getCanonicalName)
+      .enableHiveSupport()
+      .config("spark.hadoop.fs.defaultFS", hdfsURI)
+      .config("spark.ui.enabled", "false")
+      .getOrCreate()
+  }
+
+  override protected def afterAll(): Unit = {
+    try {
+      sparkSession.sessionState.catalog.reset()
+      sparkSession.stop()
+      SparkSession.clearActiveSession()
+      SparkSession.clearDefaultSession()
+    } finally {
+      sparkSession = null
+    }
+    System.clearProperty("spark.driver.port")
+
+    hdfsCluster.shutdown(true)
+
+    super.afterAll()
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Please refer #263 for more details.

This patch proposes path to be qualified with Spark default filesystem when scheme of the path is not specified.

## How was this patch tested?

Added UT. Also manually tested.

> query

```
import org.apache.spark.sql.types.StructType
val userSchema = new StructType().add("col0", "string").add("col1", "string").add("col2","string")
val df = spark.readStream.schema(userSchema).json("/tmp/stream_messages")
 df.writeStream.format("json").option("checkpointLocation","/tmp/chkpt").option("path","/tmp/hdfs_streams").start()
```

> screenshots

![Screen Shot 2019-06-08 at 12 04 49 PM](https://user-images.githubusercontent.com/1317309/59142107-aa603200-89f3-11e9-8130-1b20e0747b54.png)

![Screen Shot 2019-06-08 at 12 04 35 PM](https://user-images.githubusercontent.com/1317309/59142098-7422b280-89f3-11e9-8df4-4b61816e9d7d.png)
![Screen Shot 2019-06-08 at 12 04 43 PM](https://user-images.githubusercontent.com/1317309/59142099-7422b280-89f3-11e9-8514-8296aaabb652.png)

![Screen Shot 2019-06-08 at 12 05 01 PM](https://user-images.githubusercontent.com/1317309/59142101-7b49c080-89f3-11e9-9d30-36675495fab3.png)

Without this patch, these entities are created as `fs_path`.

This closes #263 