### PR TITLE
[SAC-269][CORE] Upgrade Atlas version to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
     <spark.version>2.4.0</spark.version>
-    <atlas.version>1.1.0</atlas.version>
+    <atlas.version>2.0.0</atlas.version>
     <maven.version>3.5.4</maven.version>
     <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
@@ -229,6 +229,12 @@
       <artifactId>hadoop-minicluster</artifactId>
       <version>2.6.5</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-configuration</groupId>
+          <artifactId>commons-configuration</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -241,6 +247,12 @@
       <groupId>org.apache.atlas</groupId>
       <artifactId>atlas-notification</artifactId>
       <version>${atlas.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.solr</groupId>
+          <artifactId>solr-test-framework</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes upgrading Atlas version to 2.0.0 which is new major version of Atlas.

This patch also excludes unnecessary dependencies which unintentionally pull commons-configuration 1.6 - maven somewhat works unwanted and assembly jar unintentionally contains commons-configuration 1.6. This patch fixes the case.

## How was this patch tested?

Existing UTs, manually tested with Apache Spark 2.4.3 & Apache Atlas 2.0. Model initialized with official spark model in Atlas (not included in any official release yet)

https://github.com/apache/atlas/blob/master/addons/models/1000-Hadoop/1100-spark_model.json

> query

```

val sourceTopics = Seq("sparksource1batch", "sparksource2batch")
val sourceTopics2 = Seq("sparksource2batch", "sparksource3batch")

val customClusterName = "custom_cluster"

val df = spark.read.format("kafka")
  .option("kafka.bootstrap.servers","localhost:9027")
  .option("subscribe", sourceTopics.mkString(","))
  .option("kafka.atlas.cluster.name", customClusterName)
  .option("startingOffsets", "earliest")
  .load()

val assignForDf2 = """{"sparksource2batch": [0, 1, 2, 3, 4], "sparksource3batch": [0, 1, 2, 3, 4]}"""

val df2 = spark.read.format("kafka")
  .option("kafka.bootstrap.servers", "localhost:9027")
  .option("assign", assignForDf2)
  .option("startingOffsets", "earliest")
  .load()

df.union(df2).write.format("kafka")
  .option("kafka.bootstrap.servers", "localhost:9027")
  .option("topic", "sparksinkbatch")
  .save()
```

> snapshots

![Screen Shot 2019-07-02 at 8 41 01 AM](https://user-images.githubusercontent.com/1317309/60472812-515b8500-9ca5-11e9-9826-6bdb4184dcfb.png)
![Screen Shot 2019-07-02 at 8 41 11 AM](https://user-images.githubusercontent.com/1317309/60472813-515b8500-9ca5-11e9-9f8f-8f6ef86daffc.png)
![Screen Shot 2019-07-02 at 8 41 17 AM](https://user-images.githubusercontent.com/1317309/60472815-51f41b80-9ca5-11e9-8015-15bd3dc56212.png)
